### PR TITLE
feat: remove deno deps after 1.38.0

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -14,7 +14,7 @@
     "daisyui": "npm:daisyui@3.9.2"
   },
   "tasks": {
-    "start": "deno task bundle && deno run -A --unstable --watch=tailwind.css,sections/,functions/,loaders/,actions/,workflows/,accounts/,.env dev.ts",
+    "start": "deno task bundle && deno run -A --unstable --env --watch=tailwind.css,sections/,functions/,loaders/,actions/,workflows/,accounts/,.env dev.ts",
     "gen": "deno run -A dev.ts --gen-only",
     "play": "USE_LOCAL_STORAGE_ONLY=true deno task start",
     "component": "deno eval 'import \"deco/scripts/component.ts\"'",

--- a/dev.ts
+++ b/dev.ts
@@ -1,6 +1,3 @@
-#!/usr/bin/env -S deno run -A --watch
-import "https://deno.land/x/dotenv@v3.2.2/load.ts";
-
 import dev from "$fresh/dev.ts";
 import config from "./fresh.config.ts";
 


### PR DESCRIPTION
Uses the new --env deno option and removes the unecessary import