### PR TITLE
fix: Events and remove Partytown

### DIFF
--- a/components/Analytics.tsx
+++ b/components/Analytics.tsx
@@ -6,15 +6,15 @@ const snippet = (id: string, event: AnalyticsEvent) => {
   const element = document.getElementById(id);
 
   if (!element) {
-    console.warn(
+    return console.warn(
       `Could not find element ${id}. Click event will not be send. This will cause loss in analytics`,
     );
-  } else {
-    element.addEventListener(
-      "click",
-      () => window.DECO.events.dispatch(event),
-    );
   }
+
+  element.addEventListener("click", () => {
+    console.log(JSON.stringify(event, null, 2));
+    window.DECO.events.dispatch(event);
+  });
 };
 
 /**
@@ -30,5 +30,5 @@ export const SendEventOnClick = <E extends AnalyticsEvent>({ event, id }: {
  * This behavior is usefull for view_* events.
  */
 export const SendEventOnLoad = <E extends AnalyticsEvent>(
-  { event }: { event: E },
+  { event }: { event: E; id?: string },
 ) => <script defer src={scriptAsDataURI(sendEvent, event)} />;

--- a/components/header/Buttons/Cart/vtex.tsx
+++ b/components/header/Buttons/Cart/vtex.tsx
@@ -3,8 +3,12 @@ import Button from "./common.tsx";
 
 function CartButton() {
   const { loading, cart } = useCart();
-  const { totalizers = [], items = [], marketingData, storePreferencesData } =
-    cart.value ?? {};
+  const {
+    totalizers = [],
+    items = [],
+    marketingData,
+    storePreferencesData,
+  } = cart.value ?? {};
   const coupon = marketingData?.coupon ?? undefined;
   const currency = storePreferencesData?.currencyCode ?? "BRL";
   const total = totalizers.find((item) => item.id === "Items")?.value ?? 0;

--- a/components/minicart/common/CartItem.tsx
+++ b/components/minicart/common/CartItem.tsx
@@ -112,11 +112,11 @@ function CartItem(
             await onUpdateQuantity(quantity, index);
 
             if (analyticsItem) {
-              analyticsItem.quantity = diff;
-
               sendEvent({
                 name: diff < 0 ? "remove_from_cart" : "add_to_cart",
-                params: { items: [analyticsItem] },
+                params: {
+                  items: [{ ...analyticsItem, quantity: Math.abs(diff) }],
+                },
               });
             }
           })}

--- a/components/product/AddToCartButton/common.tsx
+++ b/components/product/AddToCartButton/common.tsx
@@ -1,28 +1,16 @@
 import Button from "$store/components/ui/Button.tsx";
 import { sendEvent } from "$store/sdk/analytics.tsx";
 import { useUI } from "$store/sdk/useUI.ts";
+import { AddToCartParams } from "apps/commerce/types.ts";
 import { useState } from "preact/hooks";
 
 export interface Props {
   /** @description: sku name */
-  name: string;
-  productID: string;
-  productGroupID: string;
-  price: number;
-  discount: number;
-  url: string;
+  eventParams: AddToCartParams;
   onAddItem: () => Promise<void>;
 }
 
-const useAddToCart = ({
-  price,
-  name,
-  discount,
-  productGroupID,
-  productID,
-  url,
-  onAddItem,
-}: Props) => {
+const useAddToCart = ({ eventParams, onAddItem }: Props) => {
   const [loading, setLoading] = useState(false);
   const { displayCart } = useUI();
 
@@ -37,17 +25,7 @@ const useAddToCart = ({
 
       sendEvent({
         name: "add_to_cart",
-        params: {
-          items: [{
-            quantity: 1,
-            price,
-            item_url: url,
-            item_name: name,
-            discount: discount,
-            item_id: productID,
-            item_variant: name,
-          }],
-        },
+        params: eventParams,
       });
 
       displayCart.value = true;
@@ -56,14 +34,14 @@ const useAddToCart = ({
     }
   };
 
-  return { onClick, loading };
+  return { onClick, loading, "data-deco": "add-to-cart" };
 };
 
 export default function AddToCartButton(props: Props) {
   const btnProps = useAddToCart(props);
 
   return (
-    <Button {...btnProps} data-deco="add-to-cart" class="btn-primary">
+    <Button {...btnProps} class="btn-primary">
       Adicionar à Sacola
     </Button>
   );

--- a/components/product/AddToCartButton/linx.tsx
+++ b/components/product/AddToCartButton/linx.tsx
@@ -6,7 +6,7 @@ export type Props = Omit<BtnProps, "onAddItem"> & {
   productGroupID: string;
 };
 
-function AddToCartButton({ productGroupID, productID }: Props) {
+function AddToCartButton({ productGroupID, productID, eventParams }: Props) {
   const { addItem } = useCart();
 
   return (

--- a/components/product/AddToCartButton/linx.tsx
+++ b/components/product/AddToCartButton/linx.tsx
@@ -1,18 +1,21 @@
 import { useCart } from "apps/linx/hooks/useCart.ts";
 import Button, { Props as BtnProps } from "./common.tsx";
 
-export type Props = Omit<BtnProps, "onAddItem" | "platform">;
+export type Props = Omit<BtnProps, "onAddItem"> & {
+  productID: string;
+  productGroupID: string;
+};
 
-function AddToCartButton(props: Props) {
+function AddToCartButton({ productGroupID, productID }: Props) {
   const { addItem } = useCart();
 
   return (
     <Button
-      {...props}
+      eventParams={eventParams}
       onAddItem={() =>
         addItem({
-          ProductID: props.productGroupID,
-          SkuID: props.productID,
+          ProductID: productGroupID,
+          SkuID: productID,
           Quantity: 1,
         })}
     />

--- a/components/product/AddToCartButton/shopify.tsx
+++ b/components/product/AddToCartButton/shopify.tsx
@@ -1,18 +1,20 @@
 import { useCart } from "apps/shopify/hooks/useCart.ts";
 import Button, { Props as BtnProps } from "./common.tsx";
 
-export type Props = Omit<BtnProps, "onAddItem" | "platform">;
+export type Props = Omit<BtnProps, "onAddItem"> & {
+  productID: string;
+};
 
-function AddToCartButton(props: Props) {
+function AddToCartButton({ productID, eventParams }: Props) {
   const { addItems } = useCart();
   const onAddItem = () =>
     addItems({
       lines: {
-        merchandiseId: props.productID,
+        merchandiseId: productID,
       },
     });
 
-  return <Button onAddItem={onAddItem} {...props} />;
+  return <Button onAddItem={onAddItem} eventParams={eventParams} />;
 }
 
 export default AddToCartButton;

--- a/components/product/AddToCartButton/vnda.tsx
+++ b/components/product/AddToCartButton/vnda.tsx
@@ -2,22 +2,25 @@ import { PropertyValue } from "apps/commerce/types.ts";
 import { useCart } from "apps/vnda/hooks/useCart.ts";
 import Button, { Props as BtnProps } from "./common.tsx";
 
-export interface Props extends Omit<BtnProps, "onAddItem" | "platform"> {
+export interface Props extends Omit<BtnProps, "onAddItem"> {
+  productID: string;
   additionalProperty: PropertyValue[];
 }
 
-function AddToCartButton(props: Props) {
+function AddToCartButton(
+  { productID, additionalProperty, eventParams }: Props,
+) {
   const { addItem } = useCart();
   const onAddItem = () =>
     addItem({
       quantity: 1,
-      itemId: props.productID,
+      itemId: productID,
       attributes: Object.fromEntries(
-        props.additionalProperty.map(({ name, value }) => [name, value]),
+        additionalProperty.map(({ name, value }) => [name, value]),
       ),
     });
 
-  return <Button onAddItem={onAddItem} {...props} />;
+  return <Button onAddItem={onAddItem} eventParams={eventParams} />;
 }
 
 export default AddToCartButton;

--- a/components/product/AddToCartButton/vtex.tsx
+++ b/components/product/AddToCartButton/vtex.tsx
@@ -1,22 +1,23 @@
 import { useCart } from "apps/vtex/hooks/useCart.ts";
 import Button, { Props as BtnProps } from "./common.tsx";
 
-export interface Props extends Omit<BtnProps, "onAddItem" | "platform"> {
+export interface Props extends Omit<BtnProps, "onAddItem"> {
   seller: string;
+  productID: string;
 }
 
-function AddToCartButton(props: Props) {
+function AddToCartButton({ seller, productID, eventParams }: Props) {
   const { addItems } = useCart();
   const onAddItem = () =>
     addItems({
       orderItems: [{
-        id: props.productID,
-        seller: props.seller,
+        id: productID,
+        seller: seller,
         quantity: 1,
       }],
     });
 
-  return <Button onAddItem={onAddItem} {...props} />;
+  return <Button onAddItem={onAddItem} eventParams={eventParams} />;
 }
 
 export default AddToCartButton;

--- a/components/product/AddToCartButton/wake.tsx
+++ b/components/product/AddToCartButton/wake.tsx
@@ -1,19 +1,20 @@
 import { useCart } from "apps/wake/hooks/useCart.ts";
 import Button, { Props as BtnProps } from "./common.tsx";
 
-// deno-lint-ignore no-empty-interface
-export interface Props extends Omit<BtnProps, "onAddItem" | "platform"> {
+
+export interface Props extends Omit<BtnProps, "onAddItem"> {
+  productID: string;
 }
 
-function AddToCartButton(props: Props) {
+function AddToCartButton({ productID, eventParams }: Props) {
   const { addItem } = useCart();
   const onAddItem = () =>
     addItem({
-      productVariantId: Number(props.productID),
+      productVariantId: Number(productID),
       quantity: 1,
     });
 
-  return <Button onAddItem={onAddItem} {...props} />;
+  return <Button onAddItem={onAddItem} eventParams={eventParams} />;
 }
 
 export default AddToCartButton;

--- a/components/product/AddToCartButton/wake.tsx
+++ b/components/product/AddToCartButton/wake.tsx
@@ -1,7 +1,6 @@
 import { useCart } from "apps/wake/hooks/useCart.ts";
 import Button, { Props as BtnProps } from "./common.tsx";
 
-
 export interface Props extends Omit<BtnProps, "onAddItem"> {
   productID: string;
 }

--- a/components/product/ProductInfo.tsx
+++ b/components/product/ProductInfo.tsx
@@ -46,6 +46,7 @@ function ProductInfo({ page, layout }: Props) {
     gtin,
     isVariantOf,
     additionalProperty = [],
+    brand,
   } = product;
   const description = product.description || isVariantOf?.description;
   const {
@@ -57,13 +58,26 @@ function ProductInfo({ page, layout }: Props) {
   } = useOffer(offers);
   const productGroupID = isVariantOf?.productGroupID ?? "";
   const discount = price && listPrice ? listPrice - price : 0;
+  const breadcrumb = {
+    ...breadcrumbList,
+    itemListElement: breadcrumbList?.itemListElement.slice(0, -1),
+    numberOfItems: breadcrumbList.numberOfItems - 1,
+  };
+
+  const eventItem = {
+    item_list_id: "product",
+    item_list_name: "Product",
+    ...mapProductToAnalyticsItem({
+      product,
+      breadcrumbList: breadcrumb,
+      price,
+      listPrice,
+    }),
+  };
 
   return (
     <div class="flex flex-col">
-      {/* Breadcrumb */}
-      <Breadcrumb
-        itemListElement={breadcrumbList?.itemListElement.slice(0, -1)}
-      />
+      <Breadcrumb itemListElement={breadcrumb.itemListElement} />
       {/* Code and name */}
       <div class="mt-4 sm:mt-8">
         <div>
@@ -111,8 +125,11 @@ function ProductInfo({ page, layout }: Props) {
               {platform === "vtex" && (
                 <>
                   <AddToCartButtonVTEX
+                    eventParams={{ items: [eventItem] }}
                     url={url || ""}
                     name={name}
+                    groupName={isVariantOf?.name ?? ""}
+                    brand={brand?.name ?? ""}
                     productID={productID}
                     productGroupID={productGroupID}
                     price={price}
@@ -128,8 +145,11 @@ function ProductInfo({ page, layout }: Props) {
               )}
               {platform === "wake" && (
                 <AddToCartButtonWake
+                  eventParams={{ items: [eventItem] }}
                   url={url || ""}
                   name={name}
+                  groupName={isVariantOf?.name ?? ""}
+                  brand={brand?.name ?? ""}
                   productID={productID}
                   productGroupID={productGroupID}
                   price={price}
@@ -138,8 +158,11 @@ function ProductInfo({ page, layout }: Props) {
               )}
               {platform === "linx" && (
                 <AddToCartButtonLinx
+                  eventParams={{ items: [eventItem] }}
                   url={url || ""}
                   name={name}
+                  groupName={isVariantOf?.name ?? ""}
+                  brand={brand?.name ?? ""}
                   productID={productID}
                   productGroupID={productGroupID}
                   price={price}
@@ -148,8 +171,11 @@ function ProductInfo({ page, layout }: Props) {
               )}
               {platform === "vnda" && (
                 <AddToCartButtonVNDA
+                  eventParams={{ items: [eventItem] }}
                   url={url || ""}
                   name={name}
+                  groupName={isVariantOf?.name ?? ""}
+                  brand={brand?.name ?? ""}
                   productID={productID}
                   productGroupID={productGroupID}
                   price={price}
@@ -159,8 +185,11 @@ function ProductInfo({ page, layout }: Props) {
               )}
               {platform === "shopify" && (
                 <AddToCartButtonShopify
+                  eventParams={{ items: [eventItem] }}
                   url={url || ""}
                   name={name}
+                  groupName={isVariantOf?.name ?? ""}
+                  brand={brand?.name ?? ""}
                   productID={productID}
                   productGroupID={productGroupID}
                   price={price}
@@ -202,14 +231,9 @@ function ProductInfo({ page, layout }: Props) {
         event={{
           name: "view_item",
           params: {
-            items: [
-              mapProductToAnalyticsItem({
-                product,
-                breadcrumbList,
-                price,
-                listPrice,
-              }),
-            ],
+            item_list_id: "product",
+            item_list_name: "Product",
+            items: [eventItem],
           },
         }}
       />

--- a/components/product/ProductShelf.tsx
+++ b/components/product/ProductShelf.tsx
@@ -1,4 +1,4 @@
-import { SendEventOnLoad } from "$store/components/Analytics.tsx";
+import { SendEventOnView } from "$store/components/Analytics.tsx";
 import ProductCard, {
   Layout as cardLayout,
 } from "$store/components/product/ProductCard.tsx";
@@ -80,7 +80,8 @@ function ProductShelf({
           </div>
         </>
         <SliderJS rootId={id} />
-        <SendEventOnLoad
+        <SendEventOnView
+          id={id}
           event={{
             name: "view_item_list",
             params: {

--- a/components/product/ProductShelf.tsx
+++ b/components/product/ProductShelf.tsx
@@ -85,8 +85,9 @@ function ProductShelf({
             name: "view_item_list",
             params: {
               item_list_name: title,
-              items: products.map((product) =>
+              items: products.map((product, index) =>
                 mapProductToAnalyticsItem({
+                  index,
                   product,
                   ...(useOffer(product.offers)),
                 })

--- a/components/product/ProductShelfTabbed.tsx
+++ b/components/product/ProductShelfTabbed.tsx
@@ -1,4 +1,4 @@
-import { SendEventOnLoad } from "$store/components/Analytics.tsx";
+import { SendEventOnView } from "$store/components/Analytics.tsx";
 import ProductCard, {
   Layout as cardLayout,
 } from "$store/components/product/ProductCard.tsx";
@@ -106,7 +106,8 @@ function TabbedProductShelf({
           </div>
         </>
         <SliderJS rootId={id} />
-        <SendEventOnLoad
+        <SendEventOnView
+          id={id}
           event={{
             name: "view_item_list",
             params: {

--- a/components/product/ProductShelfTabbed.tsx
+++ b/components/product/ProductShelfTabbed.tsx
@@ -29,7 +29,6 @@ export interface Props {
   };
   cardLayout?: cardLayout;
   tabIndex?: number;
-  id?: string;
 }
 
 function TabbedProductShelf({
@@ -39,7 +38,6 @@ function TabbedProductShelf({
   layout,
   cardLayout,
   tabIndex,
-  id: sectionId,
 }: Props) {
   const id = useId();
   const platform = usePlatform();
@@ -113,8 +111,9 @@ function TabbedProductShelf({
             name: "view_item_list",
             params: {
               item_list_name: title,
-              items: products.map((product) =>
+              items: products.map((product, index) =>
                 mapProductToAnalyticsItem({
+                  index,
                   product,
                   ...(useOffer(product.offers)),
                 })

--- a/components/search/SearchResult.tsx
+++ b/components/search/SearchResult.tsx
@@ -1,8 +1,9 @@
-import { SendEventOnLoad } from "$store/components/Analytics.tsx";
+import { SendEventOnView } from "$store/components/Analytics.tsx";
 import { Layout as CardLayout } from "$store/components/product/ProductCard.tsx";
 import Filters from "$store/components/search/Filters.tsx";
 import Icon from "$store/components/ui/Icon.tsx";
 import SearchControls from "$store/islands/SearchControls.tsx";
+import { useId } from "$store/sdk/useId.ts";
 import { useOffer } from "$store/sdk/useOffer.ts";
 import type { ProductListingPage } from "apps/commerce/types.ts";
 import { mapProductToAnalyticsItem } from "apps/commerce/utils/productToAnalyticsItem.ts";
@@ -42,6 +43,7 @@ function Result({
   const { products, filters, breadcrumb, pageInfo, sortOptions } = page;
   const perPage = pageInfo.recordPerPage || products.length;
   const offset = pageInfo.currentPage * perPage;
+  const id = useId();
 
   return (
     <>
@@ -59,7 +61,7 @@ function Result({
               <Filters filters={filters} />
             </aside>
           )}
-          <div class="flex-grow">
+          <div class="flex-grow" id={id}>
             <ProductGallery
               products={products}
               offset={offset}
@@ -92,13 +94,14 @@ function Result({
           </div>
         </div>
       </div>
-      <SendEventOnLoad
+      <SendEventOnView
+        id={id}
         event={{
           name: "view_item_list",
           params: {
             // TODO: get category name from search or cms setting
-            item_list_name: "",
-            item_list_id: "",
+            item_list_name: breadcrumb.itemListElement?.at(-1)?.name,
+            item_list_id: breadcrumb.itemListElement?.at(-1)?.item,
             items: page.products?.map((product, index) =>
               mapProductToAnalyticsItem({
                 ...(useOffer(product.offers)),

--- a/components/search/Searchbar.tsx
+++ b/components/search/Searchbar.tsx
@@ -168,6 +168,7 @@ function Searchbar({
                     product={product}
                     platform={platform}
                     index={index}
+                    itemListName="Suggeestions"
                   />
                 </Slider.Item>
               ))}

--- a/components/ui/BannerCarousel.tsx
+++ b/components/ui/BannerCarousel.tsx
@@ -1,3 +1,7 @@
+import {
+  SendEventOnClick,
+  SendEventOnView,
+} from "$store/components/Analytics.tsx";
 import Button from "$store/components/ui/Button.tsx";
 import Icon from "$store/components/ui/Icon.tsx";
 import Slider from "$store/components/ui/Slider.tsx";
@@ -86,7 +90,9 @@ const DEFAULT_PROPS = {
   preload: true,
 };
 
-function BannerItem({ image, lcp }: { image: Banner; lcp?: boolean }) {
+function BannerItem(
+  { image, lcp, id }: { image: Banner; lcp?: boolean; id: string },
+) {
   const {
     alt,
     mobile,
@@ -96,6 +102,7 @@ function BannerItem({ image, lcp }: { image: Banner; lcp?: boolean }) {
 
   return (
     <a
+      id={id}
       href={action?.href ?? "#"}
       aria-label={action?.label}
       class="relative h-[600px] overflow-y-hidden w-full"
@@ -197,9 +204,8 @@ function Buttons() {
 }
 
 function BannerCarousel(props: Props) {
-  const { images, preload, interval } = { ...DEFAULT_PROPS, ...props };
-
   const id = useId();
+  const { images, preload, interval } = { ...DEFAULT_PROPS, ...props };
 
   return (
     <div
@@ -207,11 +213,27 @@ function BannerCarousel(props: Props) {
       class="grid grid-cols-[48px_1fr_48px] sm:grid-cols-[120px_1fr_120px] grid-rows-[1fr_48px_1fr_64px]"
     >
       <Slider class="carousel carousel-center w-full col-span-full row-span-full gap-6">
-        {images?.map((image, index) => (
-          <Slider.Item index={index} class="carousel-item w-full">
-            <BannerItem image={image} lcp={index === 0 && preload} />
-          </Slider.Item>
-        ))}
+        {images?.map((image, index) => {
+          const params = { promotion_name: image.alt };
+
+          return (
+            <Slider.Item index={index} class="carousel-item w-full">
+              <BannerItem
+                image={image}
+                lcp={index === 0 && preload}
+                id={`${id}::${index}`}
+              />
+              <SendEventOnClick
+                id={`${id}::${index}`}
+                event={{ name: "select_promotion", params }}
+              />
+              <SendEventOnView
+                id={`${id}::${index}`}
+                event={{ name: "view_promotion", params }}
+              />
+            </Slider.Item>
+          );
+        })}
       </Slider>
 
       <Buttons />

--- a/components/wishlist/WishlistButton.tsx
+++ b/components/wishlist/WishlistButton.tsx
@@ -3,6 +3,7 @@ import Icon from "$store/components/ui/Icon.tsx";
 import Button from "$store/components/ui/Button.tsx";
 import { useWishlist } from "apps/vtex/hooks/useWishlist.ts";
 import { useUser } from "apps/vtex/hooks/useUser.ts";
+import { sendEvent } from "$store/sdk/analytics.tsx";
 
 export interface Props {
   productID: string;
@@ -53,6 +54,17 @@ function WishlistButton({
             await removeItem({ id: listItem.value!.id }!);
           } else if (productID && productGroupID) {
             await addItem({ sku: productID, productId: productGroupID });
+
+            sendEvent({
+              name: "add_to_wishlist",
+              params: {
+                items: [{
+                  item_id: productID,
+                  item_group_id: productGroupID,
+                  quantity: 1,
+                }],
+              },
+            });
           }
         } finally {
           fetching.value = false;

--- a/deno.json
+++ b/deno.json
@@ -2,7 +2,7 @@
   "imports": {
     "$store/": "./",
     "deco/": "https://denopkg.com/deco-cx/deco@1.45.7/",
-    "apps/": "https://denopkg.com/deco-cx/apps@0.20.1/",
+    "apps/": "https://denopkg.com/deco-cx/apps@0.21.1/",
     "$fresh/": "https://denopkg.com/denoland/fresh@7ad4610e3a42aba42638cbc1041b96ee58a9b29e/",
     "preact": "https://esm.sh/preact@10.15.1",
     "preact/": "https://esm.sh/preact@10.15.1/",

--- a/deno.json
+++ b/deno.json
@@ -2,7 +2,7 @@
   "imports": {
     "$store/": "./",
     "deco/": "https://denopkg.com/deco-cx/deco@1.45.7/",
-    "apps/": "https://denopkg.com/deco-cx/apps@0.21.1/",
+    "apps/": "https://denopkg.com/deco-cx/apps@0.21.2/",
     "$fresh/": "https://denopkg.com/denoland/fresh@7ad4610e3a42aba42638cbc1041b96ee58a9b29e/",
     "preact": "https://esm.sh/preact@10.15.1",
     "preact/": "https://esm.sh/preact@10.15.1/",

--- a/dev.ts
+++ b/dev.ts
@@ -1,5 +1,9 @@
+import { setupGithooks } from "https://deno.land/x/githooks@0.0.4/githooks.ts";
+
 import dev from "$fresh/dev.ts";
 import config from "./fresh.config.ts";
+
+setupGithooks().catch(console.error);
 
 // Generate manifest and boot server
 await dev(import.meta.url, "./main.ts", config);

--- a/fresh.config.ts
+++ b/fresh.config.ts
@@ -1,13 +1,7 @@
 import { defineConfig } from "$fresh/server.ts";
 import plugins from "https://denopkg.com/deco-sites/std@1.22.0/plugins/mod.ts";
-import partytownPlugin from "partytown/mod.ts";
-import decoManifest from "./manifest.gen.ts";
+import manifest from "./manifest.gen.ts";
 
 export default defineConfig({
-  plugins: [
-    ...plugins({
-      manifest: decoManifest,
-    }),
-    partytownPlugin(),
-  ],
+  plugins: plugins({ manifest }),
 });

--- a/sdk/analytics.tsx
+++ b/sdk/analytics.tsx
@@ -1,4 +1,6 @@
 import type { AnalyticsEvent } from "apps/commerce/types.ts";
 
-export const sendEvent = <E extends AnalyticsEvent>(event: E) =>
+export const sendEvent = <E extends AnalyticsEvent>(event: E) => {
+  console.log(JSON.stringify(event, null, 2));
   window.DECO.events.dispatch(event);
+};


### PR DESCRIPTION
This PR:

1. Removes partytown. We discovered partytown messes with other scripts, delaying their loading and making us loose some events
2. Adds select_promotion/view_promotion events
3. Add add_to_wishlist event