### PR TITLE
Add html description attribute

### DIFF
--- a/components/product/ProductInfo.tsx
+++ b/components/product/ProductInfo.tsx
@@ -49,10 +49,7 @@ function ProductInfo({ page, layout }: Props) {
     isVariantOf,
     additionalProperty = [],
   } = product;
-
-  const descriptionHtml = additionalProperty.find(o => o['name'] == "descriptionHtml")?.value;
   const description = product.description || isVariantOf?.description;
-
   const {
     price = 0,
     listPrice,
@@ -192,7 +189,7 @@ function ProductInfo({ page, layout }: Props) {
               <summary class="cursor-pointer">Descrição</summary>
               <div
                 class="ml-2 mt-2"
-                dangerouslySetInnerHTML={{ __html: descriptionHtml ?? description }}
+                dangerouslySetInnerHTML={{ __html: description }}
               />
             </details>
           )}

--- a/components/product/ProductInfo.tsx
+++ b/components/product/ProductInfo.tsx
@@ -49,7 +49,10 @@ function ProductInfo({ page, layout }: Props) {
     isVariantOf,
     additionalProperty = [],
   } = product;
+
+  const descriptionHtml = additionalProperty.find(o => o['name'] == "descriptionHtml")?.value;
   const description = product.description || isVariantOf?.description;
+
   const {
     price = 0,
     listPrice,
@@ -189,7 +192,7 @@ function ProductInfo({ page, layout }: Props) {
               <summary class="cursor-pointer">Descrição</summary>
               <div
                 class="ml-2 mt-2"
-                dangerouslySetInnerHTML={{ __html: description }}
+                dangerouslySetInnerHTML={{ __html: descriptionHtml ?? description }}
               />
             </details>
           )}

--- a/sdk/useVariantPossiblities.ts
+++ b/sdk/useVariantPossiblities.ts
@@ -4,7 +4,7 @@ export type Possibilities = Record<string, Record<string, string | undefined>>;
 
 const hash = ({ name, value }: PropertyValue) => `${name}::${value}`;
 
-const omit = new Set(["category", "cluster", "RefId"]);
+const omit = new Set(["category", "cluster", "RefId, descriptionHtml"]);
 
 export const useVariantPossibilities = (
   variants: ProductLeaf[],

--- a/sdk/useVariantPossiblities.ts
+++ b/sdk/useVariantPossiblities.ts
@@ -4,7 +4,7 @@ export type Possibilities = Record<string, Record<string, string | undefined>>;
 
 const hash = ({ name, value }: PropertyValue) => `${name}::${value}`;
 
-const omit = new Set(["category", "cluster", "RefId, descriptionHtml"]);
+const omit = new Set(["category", "cluster", "RefId", "descriptionHtml"]);
 
 export const useVariantPossibilities = (
   variants: ProductLeaf[],


### PR DESCRIPTION
Removed the descriptionHtml additionalProperty to the ProductInfo component, made in my last PR that was closed, leaving storefront free of default behavioural changes.
Omit the additionalProperty of name "descriptionHtml" from the "useVariantPossibilities" component.
Fixed a syntax error on my previous PR