### PR TITLE
fix: dispatch correctly Events that are not using async rendering

### DIFF
--- a/components/Session.tsx
+++ b/components/Session.tsx
@@ -149,26 +149,31 @@ const sdk = () => {
           }
         })
         : null;
-      document.body.addEventListener("htmx:load", (e) =>
-        (e as unknown as {
-          detail: {
-            elt: HTMLElement;
-          };
-        })
-          .detail.elt.querySelectorAll("[data-event]").forEach((node) => {
-            const maybeTrigger = node.getAttribute("data-event-trigger");
-            const on = maybeTrigger === "click" ? "click" : "view";
-            if (on === "click") {
-              node.addEventListener("click", handleClick, {
-                passive: true,
-              });
-              return;
-            }
-            if (on === "view") {
-              handleView?.observe(node);
-              return;
-            }
-          }));
+      const listener = (node: Element) => {
+        const maybeTrigger = node.getAttribute("data-event-trigger");
+        const on = maybeTrigger === "click" ? "click" : "view";
+
+        if (on === "click") {
+          node.addEventListener("click", handleClick, {
+            passive: true,
+          });
+          return;
+        }
+
+        if (on === "view") {
+          handleView?.observe(node);
+          return;
+        }
+      };
+
+      document.body.querySelectorAll("[data-event]").forEach(listener);
+
+      document.body.addEventListener(
+        "htmx:load",
+        (e) =>
+          (e as unknown as { detail: { elt: HTMLElement } })
+            .detail.elt.querySelectorAll("[data-event]").forEach(listener),
+      );
     });
   };
   const createUserSDK = () => {

--- a/components/search/Searchbar/Form.tsx
+++ b/components/search/Searchbar/Form.tsx
@@ -9,7 +9,10 @@
  * no JavaScript is shipped to the browser!
  */
 import { Suggestion } from "apps/commerce/types.ts";
-import { SEARCHBAR_INPUT_FORM_ID, SEARCHBAR_POPUP_ID, } from "../../../constants.ts";
+import {
+  SEARCHBAR_INPUT_FORM_ID,
+  SEARCHBAR_POPUP_ID,
+} from "../../../constants.ts";
 import { useId } from "../../../sdk/useId.ts";
 import { useComponent } from "../../../sections/Component.tsx";
 import Icon from "../../ui/Icon.tsx";
@@ -22,63 +25,101 @@ export const ACTION = "/s";
 // Querystring param used when navigating the user
 export const NAME = "q";
 export interface SearchbarProps {
-    /**
-     * @title Placeholder
-     * @description Search bar default placeholder message
-     * @default What are you looking for?
-     */
-    placeholder?: string;
-    /** @description Loader to run when suggesting new elements */
-    loader: Resolved<Suggestion | null>;
+  /**
+   * @title Placeholder
+   * @description Search bar default placeholder message
+   * @default What are you looking for?
+   */
+  placeholder?: string;
+  /** @description Loader to run when suggesting new elements */
+  loader: Resolved<Suggestion | null>;
 }
 const script = (formId: string, name: string, popupId: string) => {
-    const form = document.getElementById(formId) as HTMLFormElement | null;
-    const input = form?.elements.namedItem(name) as HTMLInputElement | null;
-    form?.addEventListener("submit", () => {
-        const search_term = input?.value;
-        if (search_term) {
-            window.DECO.events.dispatch({
-                name: "search",
-                params: { search_term },
-            });
-        }
-    });
-    // Keyboard event listeners
-    addEventListener("keydown", (e: KeyboardEvent) => {
-        const isK = e.key === "k" || e.key === "K" || e.keyCode === 75;
-        // Open Searchbar on meta+k
-        if (e.metaKey === true && isK) {
-            const input = document.getElementById(popupId) as HTMLInputElement | null;
-            if (input) {
-                input.checked = true;
-                document.getElementById(formId)?.focus();
-            }
-        }
-    });
+  const form = document.getElementById(formId) as HTMLFormElement | null;
+  const input = form?.elements.namedItem(name) as HTMLInputElement | null;
+  form?.addEventListener("submit", () => {
+    const search_term = input?.value;
+    if (search_term) {
+      window.DECO.events.dispatch({
+        name: "search",
+        params: { search_term },
+      });
+    }
+  });
+  // Keyboard event listeners
+  addEventListener("keydown", (e: KeyboardEvent) => {
+    const isK = e.key === "k" || e.key === "K" || e.keyCode === 75;
+    // Open Searchbar on meta+k
+    if (e.metaKey === true && isK) {
+      const input = document.getElementById(popupId) as HTMLInputElement | null;
+      if (input) {
+        input.checked = true;
+        document.getElementById(formId)?.focus();
+      }
+    }
+  });
 };
 const Suggestions = import.meta.resolve("./Suggestions.tsx");
-export default function Searchbar({ placeholder = "What are you looking for?", loader }: SearchbarProps) {
-    const slot = useId();
-    return (<div class="w-full grid gap-8 px-4 py-6" style={{ gridTemplateRows: "min-content auto" }}>
+export default function Searchbar(
+  { placeholder = "What are you looking for?", loader }: SearchbarProps,
+) {
+  const slot = useId();
+  return (
+    <div
+      class="w-full grid gap-8 px-4 py-6"
+      style={{ gridTemplateRows: "min-content auto" }}
+    >
       <form id={SEARCHBAR_INPUT_FORM_ID} action={ACTION} class="join">
-        <button type="submit" class="btn join-item btn-square no-animation" aria-label="Search" for={SEARCHBAR_INPUT_FORM_ID} tabIndex={-1}>
-          <span class="loading loading-spinner loading-xs hidden [.htmx-request_&]:inline"/>
-          <Icon id="search" class="inline [.htmx-request_&]:hidden"/>
+        <button
+          type="submit"
+          class="btn join-item btn-square no-animation"
+          aria-label="Search"
+          for={SEARCHBAR_INPUT_FORM_ID}
+          tabIndex={-1}
+        >
+          <span class="loading loading-spinner loading-xs hidden [.htmx-request_&]:inline" />
+          <Icon id="search" class="inline [.htmx-request_&]:hidden" />
         </button>
-        <input autoFocus tabIndex={0} class="input input-bordered join-item flex-grow" name={NAME} placeholder={placeholder} autocomplete="off" hx-target={`#${slot}`} hx-post={loader && useComponent<SuggestionProps>(Suggestions, {
+        <input
+          autoFocus
+          tabIndex={0}
+          class="input input-bordered join-item flex-grow"
+          name={NAME}
+          placeholder={placeholder}
+          autocomplete="off"
+          hx-target={`#${slot}`}
+          hx-post={loader && useComponent<SuggestionProps>(Suggestions, {
             loader: asResolved(loader),
-        })} hx-trigger={`input changed delay:300ms, ${NAME}`} hx-indicator={`#${SEARCHBAR_INPUT_FORM_ID}`} hx-swap="innerHTML"/>
-        <label type="button" class="join-item btn btn-ghost btn-square hidden sm:inline-flex no-animation" for={SEARCHBAR_POPUP_ID} aria-label="Toggle searchbar">
-          <Icon id="close"/>
+          })}
+          hx-trigger={`input changed delay:300ms, ${NAME}`}
+          hx-indicator={`#${SEARCHBAR_INPUT_FORM_ID}`}
+          hx-swap="innerHTML"
+        />
+        <label
+          type="button"
+          class="join-item btn btn-ghost btn-square hidden sm:inline-flex no-animation"
+          for={SEARCHBAR_POPUP_ID}
+          aria-label="Toggle searchbar"
+        >
+          <Icon id="close" />
         </label>
       </form>
 
       {/* Suggestions slot */}
-      <div id={slot}/>
+      <div id={slot} />
 
       {/* Send search events as the user types */}
-      <script type="module" dangerouslySetInnerHTML={{
-            __html: useScript(script, SEARCHBAR_INPUT_FORM_ID, NAME, SEARCHBAR_POPUP_ID),
-        }}/>
-    </div>);
+      <script
+        type="module"
+        dangerouslySetInnerHTML={{
+          __html: useScript(
+            script,
+            SEARCHBAR_INPUT_FORM_ID,
+            NAME,
+            SEARCHBAR_POPUP_ID,
+          ),
+        }}
+      />
+    </div>
+  );
 }

--- a/components/search/Searchbar/Suggestions.tsx
+++ b/components/search/Searchbar/Suggestions.tsx
@@ -8,53 +8,63 @@ import Slider from "../../ui/Slider.tsx";
 import { ACTION, NAME } from "./Form.tsx";
 import { type Resolved } from "@deco/deco";
 export interface Props {
-    /**
-     * @title Suggestions Integration
-     * @todo: improve this typings ({query: string, count: number}) => Suggestions
-     */
-    loader: Resolved<Suggestion | null>;
+  /**
+   * @title Suggestions Integration
+   * @todo: improve this typings ({query: string, count: number}) => Suggestions
+   */
+  loader: Resolved<Suggestion | null>;
 }
 export const action = async (props: Props, req: Request, ctx: AppContext) => {
-    const { loader: { __resolveType, ...loaderProps } } = props;
-    const form = await req.formData();
-    const query = `${form.get(NAME ?? "q")}`;
-    // @ts-expect-error This is a dynamic resolved loader
-    const suggestion = await ctx.invoke(__resolveType, {
-        ...loaderProps,
-        query,
-    }) as Suggestion | null;
-    return { suggestion };
+  const { loader: { __resolveType, ...loaderProps } } = props;
+  const form = await req.formData();
+  const query = `${form.get(NAME ?? "q")}`;
+  // @ts-expect-error This is a dynamic resolved loader
+  const suggestion = await ctx.invoke(__resolveType, {
+    ...loaderProps,
+    query,
+  }) as Suggestion | null;
+  return { suggestion };
 };
 export const loader = async (props: Props, req: Request, ctx: AppContext) => {
-    const { loader: { __resolveType, ...loaderProps } } = props;
-    const query = new URL(req.url).searchParams.get(NAME ?? "q");
-    // @ts-expect-error This is a dynamic resolved loader
-    const suggestion = await ctx.invoke(__resolveType, {
-        ...loaderProps,
-        query,
-    }) as Suggestion | null;
-    return { suggestion };
+  const { loader: { __resolveType, ...loaderProps } } = props;
+  const query = new URL(req.url).searchParams.get(NAME ?? "q");
+  // @ts-expect-error This is a dynamic resolved loader
+  const suggestion = await ctx.invoke(__resolveType, {
+    ...loaderProps,
+    query,
+  }) as Suggestion | null;
+  return { suggestion };
 };
-function Suggestions({ suggestion }: ComponentProps<typeof loader, typeof action>) {
-    const { products = [], searches = [] } = suggestion ?? {};
-    const hasProducts = Boolean(products.length);
-    const hasTerms = Boolean(searches.length);
-    return (<div class={clx(`overflow-y-scroll`, !hasProducts && !hasTerms && "hidden")}>
+function Suggestions(
+  { suggestion }: ComponentProps<typeof loader, typeof action>,
+) {
+  const { products = [], searches = [] } = suggestion ?? {};
+  const hasProducts = Boolean(products.length);
+  const hasTerms = Boolean(searches.length);
+  return (
+    <div
+      class={clx(`overflow-y-scroll`, !hasProducts && !hasTerms && "hidden")}
+    >
       <div class="gap-4 grid grid-cols-1 sm:grid-rows-1 sm:grid-cols-[150px_1fr]">
         <div class="flex flex-col gap-6">
           <span class="font-medium text-xl" role="heading" aria-level={3}>
             Sugestões
           </span>
           <ul class="flex flex-col gap-6">
-            {searches.map(({ term }) => (<li>
+            {searches.map(({ term }) => (
+              <li>
                 {/* TODO @gimenes: use name and action from searchbar form */}
-                <a href={`${ACTION}?${NAME}=${term}`} class="flex gap-4 items-center">
+                <a
+                  href={`${ACTION}?${NAME}=${term}`}
+                  class="flex gap-4 items-center"
+                >
                   <span>
-                    <Icon id="search"/>
+                    <Icon id="search" />
                   </span>
-                  <span dangerouslySetInnerHTML={{ __html: term }}/>
+                  <span dangerouslySetInnerHTML={{ __html: term }} />
                 </a>
-              </li>))}
+              </li>
+            ))}
           </ul>
         </div>
         <div class="flex flex-col pt-6 md:pt-0 gap-6 overflow-x-hidden">
@@ -62,12 +72,22 @@ function Suggestions({ suggestion }: ComponentProps<typeof loader, typeof action
             Produtos sugeridos
           </span>
           <Slider class="carousel">
-            {products.map((product, index) => (<Slider.Item index={index} class="carousel-item first:ml-4 last:mr-4 min-w-[200px] max-w-[200px]">
-                <ProductCard product={product} index={index} itemListName="Suggeestions"/>
-              </Slider.Item>))}
+            {products.map((product, index) => (
+              <Slider.Item
+                index={index}
+                class="carousel-item first:ml-4 last:mr-4 min-w-[200px] max-w-[200px]"
+              >
+                <ProductCard
+                  product={product}
+                  index={index}
+                  itemListName="Suggeestions"
+                />
+              </Slider.Item>
+            ))}
           </Slider>
         </div>
       </div>
-    </div>);
+    </div>
+  );
 }
 export default Suggestions;

--- a/fresh.config.ts
+++ b/fresh.config.ts
@@ -6,5 +6,5 @@ export default defineConfig({
   plugins: plugins({
     manifest,
     htmx: true,
-          }),
+  }),
 });

--- a/sections/Category/CategoryGrid.tsx
+++ b/sections/Category/CategoryGrid.tsx
@@ -1,45 +1,74 @@
 import type { ImageWidget } from "apps/admin/widgets.ts";
 import Image from "apps/website/components/Image.tsx";
-import Section, { type Props as SectionHeaderProps, } from "../../components/ui/Section.tsx";
+import Section, {
+  type Props as SectionHeaderProps,
+} from "../../components/ui/Section.tsx";
 import Slider from "../../components/ui/Slider.tsx";
 import { clx } from "../../sdk/clx.ts";
 import { useDevice } from "@deco/deco/hooks";
 import { type LoadingFallbackProps } from "@deco/deco";
 /** @titleBy label */
 export interface Item {
-    image: ImageWidget;
-    href: string;
-    label: string;
+  image: ImageWidget;
+  href: string;
+  label: string;
 }
 export interface Props extends SectionHeaderProps {
-    items: Item[];
+  items: Item[];
 }
 function Card({ image, href, label }: Item) {
-    return (<a href={href} class="flex flex-col items-center justify-center gap-4">
+  return (
+    <a href={href} class="flex flex-col items-center justify-center gap-4">
       <div class="w-44 h-44 rounded-full bg-base-200 flex justify-center items-center border border-transparent hover:border-primary">
-        <Image src={image} alt={label} width={100} height={100} loading="lazy"/>
+        <Image
+          src={image}
+          alt={label}
+          width={100}
+          height={100}
+          loading="lazy"
+        />
       </div>
       <span class="font-medium text-sm">{label}</span>
-    </a>);
+    </a>
+  );
 }
 function CategoryGrid({ title, cta, items }: Props) {
-    const device = useDevice();
-    return (<Section.Container>
-      <Section.Header title={title} cta={cta}/>
+  const device = useDevice();
+  return (
+    <Section.Container>
+      <Section.Header title={title} cta={cta} />
 
       {device === "desktop"
-            ? (<div class="grid grid-cols-6 gap-10">
-            {items.map((i) => <Card {...i}/>)}
-          </div>)
-            : (<Slider class="carousel carousel-center sm:carousel-end gap-5 w-full">
-            {items.map((i, index) => (<Slider.Item index={index} class={clx("carousel-item", "first:pl-5 first:sm:pl-0", "last:pr-5 last:sm:pr-0")}>
-                <Card {...i}/>
-              </Slider.Item>))}
-          </Slider>)}
-    </Section.Container>);
+        ? (
+          <div class="grid grid-cols-6 gap-10">
+            {items.map((i) => <Card {...i} />)}
+          </div>
+        )
+        : (
+          <Slider class="carousel carousel-center sm:carousel-end gap-5 w-full">
+            {items.map((i, index) => (
+              <Slider.Item
+                index={index}
+                class={clx(
+                  "carousel-item",
+                  "first:pl-5 first:sm:pl-0",
+                  "last:pr-5 last:sm:pr-0",
+                )}
+              >
+                <Card {...i} />
+              </Slider.Item>
+            ))}
+          </Slider>
+        )}
+    </Section.Container>
+  );
 }
-export const LoadingFallback = ({ title, cta }: LoadingFallbackProps<Props>) => (<Section.Container>
-    <Section.Header title={title} cta={cta}/>
-    <Section.Placeholder height="212px"/>;
-  </Section.Container>);
+export const LoadingFallback = (
+  { title, cta }: LoadingFallbackProps<Props>,
+) => (
+  <Section.Container>
+    <Section.Header title={title} cta={cta} />
+    <Section.Placeholder height="212px" />;
+  </Section.Container>
+);
 export default CategoryGrid;

--- a/sections/Header/Header.tsx
+++ b/sections/Header/Header.tsx
@@ -5,47 +5,63 @@ import Alert from "../../components/header/Alert.tsx";
 import Bag from "../../components/header/Bag.tsx";
 import Menu from "../../components/header/Menu.tsx";
 import NavItem from "../../components/header/NavItem.tsx";
-import Searchbar, { type SearchbarProps, } from "../../components/search/Searchbar/Form.tsx";
+import Searchbar, {
+  type SearchbarProps,
+} from "../../components/search/Searchbar/Form.tsx";
 import Drawer from "../../components/ui/Drawer.tsx";
 import Icon from "../../components/ui/Icon.tsx";
 import Modal from "../../components/ui/Modal.tsx";
-import { HEADER_HEIGHT_DESKTOP, HEADER_HEIGHT_MOBILE, NAVBAR_HEIGHT_MOBILE, SEARCHBAR_DRAWER_ID, SEARCHBAR_POPUP_ID, SIDEMENU_CONTAINER_ID, SIDEMENU_DRAWER_ID, } from "../../constants.ts";
+import {
+  HEADER_HEIGHT_DESKTOP,
+  HEADER_HEIGHT_MOBILE,
+  NAVBAR_HEIGHT_MOBILE,
+  SEARCHBAR_DRAWER_ID,
+  SEARCHBAR_POPUP_ID,
+  SIDEMENU_CONTAINER_ID,
+  SIDEMENU_DRAWER_ID,
+} from "../../constants.ts";
 import { useDevice } from "@deco/deco/hooks";
 import { type LoadingFallbackProps } from "@deco/deco";
 export interface Logo {
-    src: ImageWidget;
-    alt: string;
-    width?: number;
-    height?: number;
+  src: ImageWidget;
+  alt: string;
+  width?: number;
+  height?: number;
 }
 export interface SectionProps {
-    alerts?: HTMLWidget[];
-    /**
-     * @title Navigation items
-     * @description Navigation items used both on mobile and desktop menus
-     */
-    navItems?: SiteNavigationElement[] | null;
-    /**
-     * @title Searchbar
-     * @description Searchbar configuration
-     */
-    searchbar: SearchbarProps;
-    /** @title Logo */
-    logo: Logo;
-    /**
-     * @description Usefull for lazy loading hidden elements, like hamburguer menus etc
-     * @hide true */
-    loading?: "eager" | "lazy";
+  alerts?: HTMLWidget[];
+  /**
+   * @title Navigation items
+   * @description Navigation items used both on mobile and desktop menus
+   */
+  navItems?: SiteNavigationElement[] | null;
+  /**
+   * @title Searchbar
+   * @description Searchbar configuration
+   */
+  searchbar: SearchbarProps;
+  /** @title Logo */
+  logo: Logo;
+  /**
+   * @description Usefull for lazy loading hidden elements, like hamburguer menus etc
+   * @hide true */
+  loading?: "eager" | "lazy";
 }
 type Props = Omit<SectionProps, "alert">;
-const Desktop = ({ navItems, logo, searchbar, loading }: Props) => (<>
+const Desktop = ({ navItems, logo, searchbar, loading }: Props) => (
+  <>
     <Modal id={SEARCHBAR_POPUP_ID}>
-      <div class="absolute top-0 bg-base-100 container" style={{ marginTop: HEADER_HEIGHT_MOBILE }}>
+      <div
+        class="absolute top-0 bg-base-100 container"
+        style={{ marginTop: HEADER_HEIGHT_MOBILE }}
+      >
         {loading === "lazy"
-        ? (<div class="flex justify-center items-center">
-              <span class="loading loading-spinner"/>
-            </div>)
-        : <Searchbar {...searchbar}/>}
+          ? (
+            <div class="flex justify-center items-center">
+              <span class="loading loading-spinner" />
+            </div>
+          )
+          : <Searchbar {...searchbar} />}
       </div>
     </Modal>
 
@@ -53,12 +69,21 @@ const Desktop = ({ navItems, logo, searchbar, loading }: Props) => (<>
       <div class="grid grid-cols-3 place-items-center">
         <div class="place-self-start">
           <a href="/" aria-label="Store logo">
-            <Image src={logo.src} alt={logo.alt} width={logo.width || 100} height={logo.height || 23}/>
+            <Image
+              src={logo.src}
+              alt={logo.alt}
+              width={logo.width || 100}
+              height={logo.height || 23}
+            />
           </a>
         </div>
 
-        <label for={SEARCHBAR_POPUP_ID} class="input input-bordered flex items-center gap-2 w-full" aria-label="search icon button">
-          <Icon id="search"/>
+        <label
+          for={SEARCHBAR_POPUP_ID}
+          class="input input-bordered flex items-center gap-2 w-full"
+          aria-label="search icon button"
+        >
+          <Icon id="search" />
           <span class="text-base-400 truncate">
             Search products, brands...
           </span>
@@ -71,71 +96,126 @@ const Desktop = ({ navItems, logo, searchbar, loading }: Props) => (<>
 
       <div class="flex justify-between items-center">
         <ul class="flex">
-          {navItems?.slice(0, 10).map((item) => <NavItem item={item}/>)}
+          {navItems?.slice(0, 10).map((item) => <NavItem item={item} />)}
         </ul>
         <div>
           {/* ship to */}
         </div>
       </div>
     </div>
-  </>);
-const Mobile = ({ logo, searchbar, navItems, loading }: Props) => (<>
-    <Drawer id={SEARCHBAR_DRAWER_ID} aside={<Drawer.Aside title="Search" drawer={SEARCHBAR_DRAWER_ID}>
+  </>
+);
+const Mobile = ({ logo, searchbar, navItems, loading }: Props) => (
+  <>
+    <Drawer
+      id={SEARCHBAR_DRAWER_ID}
+      aside={
+        <Drawer.Aside title="Search" drawer={SEARCHBAR_DRAWER_ID}>
           <div class="w-screen overflow-y-auto">
             {loading === "lazy"
-            ? (<div class="h-full w-full flex items-center justify-center">
-                  <span class="loading loading-spinner"/>
-                </div>)
-            : <Searchbar {...searchbar}/>}
+              ? (
+                <div class="h-full w-full flex items-center justify-center">
+                  <span class="loading loading-spinner" />
+                </div>
+              )
+              : <Searchbar {...searchbar} />}
           </div>
-        </Drawer.Aside>}/>
-    <Drawer id={SIDEMENU_DRAWER_ID} aside={<Drawer.Aside title="Menu" drawer={SIDEMENU_DRAWER_ID}>
+        </Drawer.Aside>
+      }
+    />
+    <Drawer
+      id={SIDEMENU_DRAWER_ID}
+      aside={
+        <Drawer.Aside title="Menu" drawer={SIDEMENU_DRAWER_ID}>
           {loading === "lazy"
-            ? (<div id={SIDEMENU_CONTAINER_ID} class="h-full flex items-center justify-center" style={{ minWidth: "100vw" }}>
-                <span class="loading loading-spinner"/>
-              </div>)
-            : <Menu navItems={navItems ?? []}/>}
-        </Drawer.Aside>}/>
+            ? (
+              <div
+                id={SIDEMENU_CONTAINER_ID}
+                class="h-full flex items-center justify-center"
+                style={{ minWidth: "100vw" }}
+              >
+                <span class="loading loading-spinner" />
+              </div>
+            )
+            : <Menu navItems={navItems ?? []} />}
+        </Drawer.Aside>
+      }
+    />
 
-    <div class="grid place-items-center w-screen px-5 gap-4" style={{
+    <div
+      class="grid place-items-center w-screen px-5 gap-4"
+      style={{
         height: NAVBAR_HEIGHT_MOBILE,
-        gridTemplateColumns: "min-content auto min-content min-content min-content",
-    }}>
-      <label for={SIDEMENU_DRAWER_ID} class="btn btn-square btn-sm btn-ghost" aria-label="open menu">
-        <Icon id="menu"/>
+        gridTemplateColumns:
+          "min-content auto min-content min-content min-content",
+      }}
+    >
+      <label
+        for={SIDEMENU_DRAWER_ID}
+        class="btn btn-square btn-sm btn-ghost"
+        aria-label="open menu"
+      >
+        <Icon id="menu" />
       </label>
 
-      {logo && (<a href="/" class="flex-grow inline-flex items-center justify-center" style={{ minHeight: NAVBAR_HEIGHT_MOBILE }} aria-label="Store logo">
-          <Image src={logo.src} alt={logo.alt} width={logo.width || 100} height={logo.height || 13}/>
-        </a>)}
+      {logo && (
+        <a
+          href="/"
+          class="flex-grow inline-flex items-center justify-center"
+          style={{ minHeight: NAVBAR_HEIGHT_MOBILE }}
+          aria-label="Store logo"
+        >
+          <Image
+            src={logo.src}
+            alt={logo.alt}
+            width={logo.width || 100}
+            height={logo.height || 13}
+          />
+        </a>
+      )}
 
-      <label for={SEARCHBAR_DRAWER_ID} class="btn btn-square btn-sm btn-ghost" aria-label="search icon button">
-        <Icon id="search"/>
+      <label
+        for={SEARCHBAR_DRAWER_ID}
+        class="btn btn-square btn-sm btn-ghost"
+        aria-label="search icon button"
+      >
+        <Icon id="search" />
       </label>
       <Bag />
     </div>
-  </>);
-function Header({ alerts = [], logo = {
-    src: "https://ozksgdmyrqcxcwhnbepg.supabase.co/storage/v1/object/public/assets/2291/986b61d4-3847-4867-93c8-b550cb459cc7",
+  </>
+);
+function Header({
+  alerts = [],
+  logo = {
+    src:
+      "https://ozksgdmyrqcxcwhnbepg.supabase.co/storage/v1/object/public/assets/2291/986b61d4-3847-4867-93c8-b550cb459cc7",
     width: 100,
     height: 16,
     alt: "Logo",
-}, ...props }: Props) {
-    const device = useDevice();
-    return (<header style={{
-            height: device === "desktop"
-                ? HEADER_HEIGHT_DESKTOP
-                : HEADER_HEIGHT_MOBILE,
-        }}>
+  },
+  ...props
+}: Props) {
+  const device = useDevice();
+  return (
+    <header
+      style={{
+        height: device === "desktop"
+          ? HEADER_HEIGHT_DESKTOP
+          : HEADER_HEIGHT_MOBILE,
+      }}
+    >
       <div class="bg-base-100 fixed w-full z-40">
-        {alerts.length > 0 && <Alert alerts={alerts}/>}
+        {alerts.length > 0 && <Alert alerts={alerts} />}
         {device === "desktop"
-            ? <Desktop logo={logo} {...props}/>
-            : <Mobile logo={logo} {...props}/>}
+          ? <Desktop logo={logo} {...props} />
+          : <Mobile logo={logo} {...props} />}
       </div>
-    </header>);
+    </header>
+  );
 }
 export const LoadingFallback = (props: LoadingFallbackProps<Props>) => (
-// deno-lint-ignore no-explicit-any
-<Header {...props as any} loading="lazy"/>);
+  // deno-lint-ignore no-explicit-any
+  <Header {...props as any} loading="lazy" />
+);
 export default Header;

--- a/sections/Images/ImageGallery.tsx
+++ b/sections/Images/ImageGallery.tsx
@@ -1,73 +1,114 @@
 import { type ImageWidget } from "apps/admin/widgets.ts";
 import { Picture, Source } from "apps/website/components/Picture.tsx";
-import Section, { type Props as SectionHeaderProps, } from "../../components/ui/Section.tsx";
+import Section, {
+  type Props as SectionHeaderProps,
+} from "../../components/ui/Section.tsx";
 import { type LoadingFallbackProps } from "@deco/deco";
 /**
  * @titleBy alt
  */
 interface Banner {
-    mobile: ImageWidget;
-    desktop?: ImageWidget;
-    /** @description Image alt texts */
-    alt: string;
-    /** @description Adicione um link */
-    href: string;
+  mobile: ImageWidget;
+  desktop?: ImageWidget;
+  /** @description Image alt texts */
+  alt: string;
+  /** @description Adicione um link */
+  href: string;
 }
 interface Props extends SectionHeaderProps {
-    /**
-     * @maxItems 4
-     * @minItems 4
-     */
-    banners?: Banner[];
+  /**
+   * @maxItems 4
+   * @minItems 4
+   */
+  banners?: Banner[];
 }
 function Banner({ mobile, desktop, alt, href }: Banner) {
-    return (<a href={href} class="overflow-hidden">
+  return (
+    <a href={href} class="overflow-hidden">
       <Picture>
-        <Source width={190} height={190} media="(max-width: 767px)" src={mobile}/>
-        <Source width={640} height={420} media="(min-width: 768px)" src={desktop || mobile}/>
-        <img width={640} class="w-full h-full object-cover" src={mobile} alt={alt} decoding="async" loading="lazy"/>
+        <Source
+          width={190}
+          height={190}
+          media="(max-width: 767px)"
+          src={mobile}
+        />
+        <Source
+          width={640}
+          height={420}
+          media="(min-width: 768px)"
+          src={desktop || mobile}
+        />
+        <img
+          width={640}
+          class="w-full h-full object-cover"
+          src={mobile}
+          alt={alt}
+          decoding="async"
+          loading="lazy"
+        />
       </Picture>
-    </a>);
+    </a>
+  );
 }
-function Gallery({ title, cta, banners = [
+function Gallery({
+  title,
+  cta,
+  banners = [
     {
-        mobile: "https://ozksgdmyrqcxcwhnbepg.supabase.co/storage/v1/object/public/assets/239/b531631b-8523-4feb-ac37-5112873abad2",
-        desktop: "https://ozksgdmyrqcxcwhnbepg.supabase.co/storage/v1/object/public/assets/239/b531631b-8523-4feb-ac37-5112873abad2",
-        alt: "Fashion",
-        href: "/",
+      mobile:
+        "https://ozksgdmyrqcxcwhnbepg.supabase.co/storage/v1/object/public/assets/239/b531631b-8523-4feb-ac37-5112873abad2",
+      desktop:
+        "https://ozksgdmyrqcxcwhnbepg.supabase.co/storage/v1/object/public/assets/239/b531631b-8523-4feb-ac37-5112873abad2",
+      alt: "Fashion",
+      href: "/",
     },
     {
-        alt: "Fashion",
-        href: "/",
-        mobile: "https://ozksgdmyrqcxcwhnbepg.supabase.co/storage/v1/object/public/assets/239/1125d938-89ff-4aae-a354-63d4241394a6",
-        desktop: "https://ozksgdmyrqcxcwhnbepg.supabase.co/storage/v1/object/public/assets/239/1125d938-89ff-4aae-a354-63d4241394a6",
+      alt: "Fashion",
+      href: "/",
+      mobile:
+        "https://ozksgdmyrqcxcwhnbepg.supabase.co/storage/v1/object/public/assets/239/1125d938-89ff-4aae-a354-63d4241394a6",
+      desktop:
+        "https://ozksgdmyrqcxcwhnbepg.supabase.co/storage/v1/object/public/assets/239/1125d938-89ff-4aae-a354-63d4241394a6",
     },
     {
-        mobile: "https://ozksgdmyrqcxcwhnbepg.supabase.co/storage/v1/object/public/assets/239/dd1e2acb-ff80-49f9-8f56-1deac3b7a42d",
-        desktop: "https://ozksgdmyrqcxcwhnbepg.supabase.co/storage/v1/object/public/assets/239/dd1e2acb-ff80-49f9-8f56-1deac3b7a42d",
-        href: "/",
-        alt: "Fashion",
+      mobile:
+        "https://ozksgdmyrqcxcwhnbepg.supabase.co/storage/v1/object/public/assets/239/dd1e2acb-ff80-49f9-8f56-1deac3b7a42d",
+      desktop:
+        "https://ozksgdmyrqcxcwhnbepg.supabase.co/storage/v1/object/public/assets/239/dd1e2acb-ff80-49f9-8f56-1deac3b7a42d",
+      href: "/",
+      alt: "Fashion",
     },
     {
-        mobile: "https://ozksgdmyrqcxcwhnbepg.supabase.co/storage/v1/object/public/assets/239/0b85ba2d-48b1-4f5b-b619-7f4a7f50b455",
-        desktop: "https://ozksgdmyrqcxcwhnbepg.supabase.co/storage/v1/object/public/assets/239/0b85ba2d-48b1-4f5b-b619-7f4a7f50b455",
-        alt: "Fashion",
-        href: "/",
+      mobile:
+        "https://ozksgdmyrqcxcwhnbepg.supabase.co/storage/v1/object/public/assets/239/0b85ba2d-48b1-4f5b-b619-7f4a7f50b455",
+      desktop:
+        "https://ozksgdmyrqcxcwhnbepg.supabase.co/storage/v1/object/public/assets/239/0b85ba2d-48b1-4f5b-b619-7f4a7f50b455",
+      alt: "Fashion",
+      href: "/",
     },
-], }: Props) {
-    return (<Section.Container>
-      <Section.Header title={title} cta={cta}/>
+  ],
+}: Props) {
+  return (
+    <Section.Container>
+      <Section.Header title={title} cta={cta} />
 
       <ul class="grid gap-2 sm:gap-4 grid-cols-1 sm:grid-cols-2 px-5 sm:px-0">
-        {banners.map((item) => (<li>
-            <Banner {...item}/>
-          </li>))}
+        {banners.map((item) => (
+          <li>
+            <Banner {...item} />
+          </li>
+        ))}
       </ul>
-    </Section.Container>);
+    </Section.Container>
+  );
 }
-export const LoadingFallback = ({ title, cta }: LoadingFallbackProps<Props>) => (<Section.Container>
-    <Section.Header title={title} cta={cta}/>
+export const LoadingFallback = (
+  { title, cta }: LoadingFallbackProps<Props>,
+) => (
+  <Section.Container>
+    <Section.Header title={title} cta={cta} />
 
-    <Section.Placeholder height="635px"/>;
-  </Section.Container>);
+    <Section.Placeholder height="635px" />;
+  </Section.Container>
+);
 export default Gallery;

--- a/sections/Product/ProductShelf.tsx
+++ b/sections/Product/ProductShelf.tsx
@@ -1,38 +1,48 @@
 import type { Product } from "apps/commerce/types.ts";
 import { mapProductToAnalyticsItem } from "apps/commerce/utils/productToAnalyticsItem.ts";
 import ProductSlider from "../../components/product/ProductSlider.tsx";
-import Section, { Props as SectionHeaderProps, } from "../../components/ui/Section.tsx";
+import Section, {
+  Props as SectionHeaderProps,
+} from "../../components/ui/Section.tsx";
 import { useOffer } from "../../sdk/useOffer.ts";
 import { useSendEvent } from "../../sdk/useSendEvent.ts";
 import { type LoadingFallbackProps } from "@deco/deco";
 export interface Props extends SectionHeaderProps {
-    products: Product[] | null;
+  products: Product[] | null;
 }
 export default function ProductShelf({ products, title, cta }: Props) {
-    if (!products || products.length === 0) {
-        return null;
-    }
-    const viewItemListEvent = useSendEvent({
-        on: "view",
-        event: {
-            name: "view_item_list",
-            params: {
-                item_list_name: title,
-                items: products.map((product, index) => mapProductToAnalyticsItem({
-                    index,
-                    product,
-                    ...(useOffer(product.offers)),
-                })),
-            },
-        },
-    });
-    return (<Section.Container {...viewItemListEvent}>
-      <Section.Header title={title} cta={cta}/>
+  if (!products || products.length === 0) {
+    return null;
+  }
+  const viewItemListEvent = useSendEvent({
+    on: "view",
+    event: {
+      name: "view_item_list",
+      params: {
+        item_list_name: title,
+        items: products.map((product, index) =>
+          mapProductToAnalyticsItem({
+            index,
+            product,
+            ...(useOffer(product.offers)),
+          })
+        ),
+      },
+    },
+  });
+  return (
+    <Section.Container {...viewItemListEvent}>
+      <Section.Header title={title} cta={cta} />
 
-      <ProductSlider products={products} itemListName={title}/>
-    </Section.Container>);
+      <ProductSlider products={products} itemListName={title} />
+    </Section.Container>
+  );
 }
-export const LoadingFallback = ({ title, cta }: LoadingFallbackProps<Props>) => (<Section.Container>
-    <Section.Header title={title} cta={cta}/>
-    <Section.Placeholder height="471px"/>;
-  </Section.Container>);
+export const LoadingFallback = (
+  { title, cta }: LoadingFallbackProps<Props>,
+) => (
+  <Section.Container>
+    <Section.Header title={title} cta={cta} />
+    <Section.Placeholder height="471px" />;
+  </Section.Container>
+);

--- a/sections/Product/ProductShelfTabbed.tsx
+++ b/sections/Product/ProductShelfTabbed.tsx
@@ -1,57 +1,71 @@
 import type { Product } from "apps/commerce/types.ts";
 import { mapProductToAnalyticsItem } from "apps/commerce/utils/productToAnalyticsItem.ts";
 import ProductSlider from "../../components/product/ProductSlider.tsx";
-import Section, { Props as SectionHeaderProps, } from "../../components/ui/Section.tsx";
+import Section, {
+  Props as SectionHeaderProps,
+} from "../../components/ui/Section.tsx";
 import { useOffer } from "../../sdk/useOffer.ts";
 import { useSendEvent } from "../../sdk/useSendEvent.ts";
 import { type LoadingFallbackProps } from "@deco/deco";
 /** @titleBy title */
 interface Tab {
-    title: string;
-    products: Product[] | null;
+  title: string;
+  products: Product[] | null;
 }
 export interface Props extends SectionHeaderProps {
-    tabs: Tab[];
-    /** @hide true */
-    tabIndex?: number;
+  tabs: Tab[];
+  /** @hide true */
+  tabIndex?: number;
 }
-export default function TabbedProductShelf({ tabs, title, cta, tabIndex }: Props) {
-    const ti = typeof tabIndex === "number"
-        ? Math.min(Math.max(tabIndex, 0), tabs.length)
-        : 0;
-    const { products } = tabs[ti];
-    const viewItemListEvent = useSendEvent({
-        on: "view",
-        event: {
-            name: "view_item_list",
-            params: {
-                item_list_name: title,
-                items: products?.map((product, index) => mapProductToAnalyticsItem({
-                    index,
-                    product,
-                    ...(useOffer(product.offers)),
-                })) ?? [],
-            },
-        },
-    });
-    return (<Section.Container {...viewItemListEvent}>
-      <Section.Header title={title} cta={cta}/>
+export default function TabbedProductShelf(
+  { tabs, title, cta, tabIndex }: Props,
+) {
+  const ti = typeof tabIndex === "number"
+    ? Math.min(Math.max(tabIndex, 0), tabs.length)
+    : 0;
+  const { products } = tabs[ti];
+  const viewItemListEvent = useSendEvent({
+    on: "view",
+    event: {
+      name: "view_item_list",
+      params: {
+        item_list_name: title,
+        items: products?.map((product, index) =>
+          mapProductToAnalyticsItem({
+            index,
+            product,
+            ...(useOffer(product.offers)),
+          })
+        ) ?? [],
+      },
+    },
+  });
+  return (
+    <Section.Container {...viewItemListEvent}>
+      <Section.Header title={title} cta={cta} />
 
       <Section.Tabbed>
         {!products?.length
-            ? (<div class="flex justify-center items-center">
+          ? (
+            <div class="flex justify-center items-center">
               No Products found
-            </div>)
-            : <ProductSlider products={products} itemListName={title}/>}
+            </div>
+          )
+          : <ProductSlider products={products} itemListName={title} />}
       </Section.Tabbed>
-    </Section.Container>);
+    </Section.Container>
+  );
 }
-export const LoadingFallback = ({ title, cta }: LoadingFallbackProps<Props>) => (<Section.Container>
-    <Section.Header title={title} cta={cta}/>
+export const LoadingFallback = (
+  { title, cta }: LoadingFallbackProps<Props>,
+) => (
+  <Section.Container>
+    <Section.Header title={title} cta={cta} />
 
     <Section.Tabbed>
       <>
-        <Section.Placeholder height="471px"/>;
+        <Section.Placeholder height="471px" />;
       </>
     </Section.Tabbed>
-  </Section.Container>);
+  </Section.Container>
+);

--- a/sections/Social/InstagramPosts.tsx
+++ b/sections/Social/InstagramPosts.tsx
@@ -1,106 +1,145 @@
 import Image from "apps/website/components/Image.tsx";
-import Section, { type Props as SectionHeaderProps, } from "../../components/ui/Section.tsx";
+import Section, {
+  type Props as SectionHeaderProps,
+} from "../../components/ui/Section.tsx";
 import Slider from "../../components/ui/Slider.tsx";
 import { clx } from "../../sdk/clx.ts";
 import { type SectionProps } from "@deco/deco";
 import { type LoadingFallbackProps } from "@deco/deco";
 export interface Data {
-    id: string;
-    permalink: string;
-    media_type: string;
-    media_url: string;
+  id: string;
+  permalink: string;
+  media_type: string;
+  media_url: string;
 }
 export interface Props extends SectionHeaderProps {
-    /**
-     * @description Get it in Facebook app. Expires every 90 days.
-     */
-    facebookToken: string;
-    /**
-     * @title Number of posts
-     */
-    nposts: number;
+  /**
+   * @description Get it in Facebook app. Expires every 90 days.
+   */
+  facebookToken: string;
+  /**
+   * @title Number of posts
+   */
+  nposts: number;
 }
 const FIELDS = "media_url,media_type,permalink";
 const fetchPosts = async (token: string): Promise<Data[]> => {
-    try {
-        const response = await fetch(`https://graph.instagram.com/me/media?access_token=${token}&fields=${FIELDS}`);
-        if (!response.ok) {
-            throw new Error(await response.text());
-        }
-        const json = await response.json() as {
-            data: Data[];
-        };
-        return json.data;
+  try {
+    const response = await fetch(
+      `https://graph.instagram.com/me/media?access_token=${token}&fields=${FIELDS}`,
+    );
+    if (!response.ok) {
+      throw new Error(await response.text());
     }
-    catch (error) {
-        console.error("Instagram API returned the following error:", error);
-        return [
-            {
-                id: "placeholderInsta",
-                permalink: "#",
-                media_type: "IMAGE",
-                media_url: "https://instagram.fssz12-1.fna.fbcdn.net/v/t39.30808-6/448303338_17946815738811617_8627590492190753324_n.jpg?stp=dst-jpg_e15&efg=eyJ2ZW5jb2RlX3RhZyI6ImltYWdlX3VybGdlbi4yMDQ4eDIwNDguc2RyLmYzMDgwOCJ9&_nc_ht=instagram.fssz12-1.fna.fbcdn.net&_nc_cat=105&_nc_ohc=0hgWwQSVXWoQ7kNvgHTTe_b&edm=AEhyXUkAAAAA&ccb=7-5&ig_cache_key=MzM4OTc1MTE2MzU5ODI3NjEyMQ%3D%3D.2-ccb7-5&oh=00_AYBoM5AbNhOTtdCFcbcmqOEIkF4lC2EGH33vnI_7VKRPXA&oe=667624C1&_nc_sid=cf751b",
-            },
-            {
-                id: "placeholderInsta",
-                permalink: "#",
-                media_type: "IMAGE",
-                media_url: "https://instagram.fssz12-1.fna.fbcdn.net/v/t39.30808-6/444470593_17944916675811617_2966115177721160533_n.jpg?stp=dst-jpg_e35_s1080x1080_sh0.08&efg=eyJ2ZW5jb2RlX3RhZyI6ImltYWdlX3VybGdlbi4xNDQweDExNTIuc2RyLmYzMDgwOCJ9&_nc_ht=instagram.fssz12-1.fna.fbcdn.net&_nc_cat=105&_nc_ohc=RMg3-8nrag0Q7kNvgFgvV_p&edm=AEhyXUkAAAAA&ccb=7-5&ig_cache_key=MzM3ODc3NjMzNjI4NDM1ODE5NQ%3D%3D.2-ccb7-5&oh=00_AYC_oc0Sa1Eh_bTpaJZxWftQ3yiYmf8n1H7cbsGjBkhhIw&oe=66742AF7&_nc_sid=cf751b",
-            },
-            {
-                id: "placeholderInsta",
-                permalink: "",
-                media_type: "IMAGE",
-                media_url: "https://instagram.fssz12-1.fna.fbcdn.net/v/t39.30808-6/441497292_17943172355811617_8109128954771263459_n.jpg?stp=dst-jpg_e15&efg=eyJ2ZW5jb2RlX3RhZyI6ImltYWdlX3VybGdlbi4xMDk4eDEwOTguc2RyLmYzMDgwOCJ9&_nc_ht=instagram.fssz12-1.fna.fbcdn.net&_nc_cat=105&_nc_ohc=WqsUNdtOX5EQ7kNvgFns-_p&edm=AFg4Q8wAAAAA&ccb=7-5&ig_cache_key=MzM2Nzk4OTkyMTY3ODM4ODc2MA%3D%3D.2-ccb7-5&oh=00_AYCZubDrz_s3R9n30heRJ_xOzerTgNT5Hlv1ut7oGVg6rw&oe=66760991&_nc_sid=cf751b",
-            },
-        ];
-    }
-};
-export async function loader({ facebookToken, nposts, ...rest }: Props, _req: Request) {
-    const posts = await fetchPosts(facebookToken);
-    return {
-        ...rest,
-        posts: posts.slice(0, nposts ?? 12),
+    const json = await response.json() as {
+      data: Data[];
     };
+    return json.data;
+  } catch (error) {
+    console.error("Instagram API returned the following error:", error);
+    return [
+      {
+        id: "placeholderInsta",
+        permalink: "#",
+        media_type: "IMAGE",
+        media_url:
+          "https://instagram.fssz12-1.fna.fbcdn.net/v/t39.30808-6/448303338_17946815738811617_8627590492190753324_n.jpg?stp=dst-jpg_e15&efg=eyJ2ZW5jb2RlX3RhZyI6ImltYWdlX3VybGdlbi4yMDQ4eDIwNDguc2RyLmYzMDgwOCJ9&_nc_ht=instagram.fssz12-1.fna.fbcdn.net&_nc_cat=105&_nc_ohc=0hgWwQSVXWoQ7kNvgHTTe_b&edm=AEhyXUkAAAAA&ccb=7-5&ig_cache_key=MzM4OTc1MTE2MzU5ODI3NjEyMQ%3D%3D.2-ccb7-5&oh=00_AYBoM5AbNhOTtdCFcbcmqOEIkF4lC2EGH33vnI_7VKRPXA&oe=667624C1&_nc_sid=cf751b",
+      },
+      {
+        id: "placeholderInsta",
+        permalink: "#",
+        media_type: "IMAGE",
+        media_url:
+          "https://instagram.fssz12-1.fna.fbcdn.net/v/t39.30808-6/444470593_17944916675811617_2966115177721160533_n.jpg?stp=dst-jpg_e35_s1080x1080_sh0.08&efg=eyJ2ZW5jb2RlX3RhZyI6ImltYWdlX3VybGdlbi4xNDQweDExNTIuc2RyLmYzMDgwOCJ9&_nc_ht=instagram.fssz12-1.fna.fbcdn.net&_nc_cat=105&_nc_ohc=RMg3-8nrag0Q7kNvgFgvV_p&edm=AEhyXUkAAAAA&ccb=7-5&ig_cache_key=MzM3ODc3NjMzNjI4NDM1ODE5NQ%3D%3D.2-ccb7-5&oh=00_AYC_oc0Sa1Eh_bTpaJZxWftQ3yiYmf8n1H7cbsGjBkhhIw&oe=66742AF7&_nc_sid=cf751b",
+      },
+      {
+        id: "placeholderInsta",
+        permalink: "",
+        media_type: "IMAGE",
+        media_url:
+          "https://instagram.fssz12-1.fna.fbcdn.net/v/t39.30808-6/441497292_17943172355811617_8109128954771263459_n.jpg?stp=dst-jpg_e15&efg=eyJ2ZW5jb2RlX3RhZyI6ImltYWdlX3VybGdlbi4xMDk4eDEwOTguc2RyLmYzMDgwOCJ9&_nc_ht=instagram.fssz12-1.fna.fbcdn.net&_nc_cat=105&_nc_ohc=WqsUNdtOX5EQ7kNvgFns-_p&edm=AFg4Q8wAAAAA&ccb=7-5&ig_cache_key=MzM2Nzk4OTkyMTY3ODM4ODc2MA%3D%3D.2-ccb7-5&oh=00_AYCZubDrz_s3R9n30heRJ_xOzerTgNT5Hlv1ut7oGVg6rw&oe=66760991&_nc_sid=cf751b",
+      },
+    ];
+  }
+};
+export async function loader(
+  { facebookToken, nposts, ...rest }: Props,
+  _req: Request,
+) {
+  const posts = await fetchPosts(facebookToken);
+  return {
+    ...rest,
+    posts: posts.slice(0, nposts ?? 12),
+  };
 }
-function InstagramPosts({ title, posts = [
+function InstagramPosts({
+  title,
+  posts = [
     {
-        id: "placeholderInsta",
-        permalink: "#",
-        media_type: "IMAGE",
-        media_url: "https://instagram.fssz12-1.fna.fbcdn.net/v/t39.30808-6/448303338_17946815738811617_8627590492190753324_n.jpg?stp=dst-jpg_e15&efg=eyJ2ZW5jb2RlX3RhZyI6ImltYWdlX3VybGdlbi4yMDQ4eDIwNDguc2RyLmYzMDgwOCJ9&_nc_ht=instagram.fssz12-1.fna.fbcdn.net&_nc_cat=105&_nc_ohc=0hgWwQSVXWoQ7kNvgHTTe_b&edm=AEhyXUkAAAAA&ccb=7-5&ig_cache_key=MzM4OTc1MTE2MzU5ODI3NjEyMQ%3D%3D.2-ccb7-5&oh=00_AYBoM5AbNhOTtdCFcbcmqOEIkF4lC2EGH33vnI_7VKRPXA&oe=667624C1&_nc_sid=cf751b",
+      id: "placeholderInsta",
+      permalink: "#",
+      media_type: "IMAGE",
+      media_url:
+        "https://instagram.fssz12-1.fna.fbcdn.net/v/t39.30808-6/448303338_17946815738811617_8627590492190753324_n.jpg?stp=dst-jpg_e15&efg=eyJ2ZW5jb2RlX3RhZyI6ImltYWdlX3VybGdlbi4yMDQ4eDIwNDguc2RyLmYzMDgwOCJ9&_nc_ht=instagram.fssz12-1.fna.fbcdn.net&_nc_cat=105&_nc_ohc=0hgWwQSVXWoQ7kNvgHTTe_b&edm=AEhyXUkAAAAA&ccb=7-5&ig_cache_key=MzM4OTc1MTE2MzU5ODI3NjEyMQ%3D%3D.2-ccb7-5&oh=00_AYBoM5AbNhOTtdCFcbcmqOEIkF4lC2EGH33vnI_7VKRPXA&oe=667624C1&_nc_sid=cf751b",
     },
     {
-        id: "placeholderInsta",
-        permalink: "#",
-        media_type: "IMAGE",
-        media_url: "https://instagram.fssz12-1.fna.fbcdn.net/v/t39.30808-6/444470593_17944916675811617_2966115177721160533_n.jpg?stp=dst-jpg_e35_s1080x1080_sh0.08&efg=eyJ2ZW5jb2RlX3RhZyI6ImltYWdlX3VybGdlbi4xNDQweDExNTIuc2RyLmYzMDgwOCJ9&_nc_ht=instagram.fssz12-1.fna.fbcdn.net&_nc_cat=105&_nc_ohc=RMg3-8nrag0Q7kNvgFgvV_p&edm=AEhyXUkAAAAA&ccb=7-5&ig_cache_key=MzM3ODc3NjMzNjI4NDM1ODE5NQ%3D%3D.2-ccb7-5&oh=00_AYC_oc0Sa1Eh_bTpaJZxWftQ3yiYmf8n1H7cbsGjBkhhIw&oe=66742AF7&_nc_sid=cf751b",
+      id: "placeholderInsta",
+      permalink: "#",
+      media_type: "IMAGE",
+      media_url:
+        "https://instagram.fssz12-1.fna.fbcdn.net/v/t39.30808-6/444470593_17944916675811617_2966115177721160533_n.jpg?stp=dst-jpg_e35_s1080x1080_sh0.08&efg=eyJ2ZW5jb2RlX3RhZyI6ImltYWdlX3VybGdlbi4xNDQweDExNTIuc2RyLmYzMDgwOCJ9&_nc_ht=instagram.fssz12-1.fna.fbcdn.net&_nc_cat=105&_nc_ohc=RMg3-8nrag0Q7kNvgFgvV_p&edm=AEhyXUkAAAAA&ccb=7-5&ig_cache_key=MzM3ODc3NjMzNjI4NDM1ODE5NQ%3D%3D.2-ccb7-5&oh=00_AYC_oc0Sa1Eh_bTpaJZxWftQ3yiYmf8n1H7cbsGjBkhhIw&oe=66742AF7&_nc_sid=cf751b",
     },
     {
-        id: "placeholderInsta",
-        permalink: "#",
-        media_type: "IMAGE",
-        media_url: "https://instagram.fssz12-1.fna.fbcdn.net/v/t39.30808-6/441497292_17943172355811617_8109128954771263459_n.jpg?stp=dst-jpg_e15&efg=eyJ2ZW5jb2RlX3RhZyI6ImltYWdlX3VybGdlbi4xMDk4eDEwOTguc2RyLmYzMDgwOCJ9&_nc_ht=instagram.fssz12-1.fna.fbcdn.net&_nc_cat=105&_nc_ohc=WqsUNdtOX5EQ7kNvgFns-_p&edm=AFg4Q8wAAAAA&ccb=7-5&ig_cache_key=MzM2Nzk4OTkyMTY3ODM4ODc2MA%3D%3D.2-ccb7-5&oh=00_AYCZubDrz_s3R9n30heRJ_xOzerTgNT5Hlv1ut7oGVg6rw&oe=66760991&_nc_sid=cf751b",
+      id: "placeholderInsta",
+      permalink: "#",
+      media_type: "IMAGE",
+      media_url:
+        "https://instagram.fssz12-1.fna.fbcdn.net/v/t39.30808-6/441497292_17943172355811617_8109128954771263459_n.jpg?stp=dst-jpg_e15&efg=eyJ2ZW5jb2RlX3RhZyI6ImltYWdlX3VybGdlbi4xMDk4eDEwOTguc2RyLmYzMDgwOCJ9&_nc_ht=instagram.fssz12-1.fna.fbcdn.net&_nc_cat=105&_nc_ohc=WqsUNdtOX5EQ7kNvgFns-_p&edm=AFg4Q8wAAAAA&ccb=7-5&ig_cache_key=MzM2Nzk4OTkyMTY3ODM4ODc2MA%3D%3D.2-ccb7-5&oh=00_AYCZubDrz_s3R9n30heRJ_xOzerTgNT5Hlv1ut7oGVg6rw&oe=66760991&_nc_sid=cf751b",
     },
-], }: SectionProps<typeof loader>) {
-    return (<Section.Container>
-      <Section.Header title={title}/>
+  ],
+}: SectionProps<typeof loader>) {
+  return (
+    <Section.Container>
+      <Section.Header title={title} />
 
       <Slider class="carousel carousel-center sm:carousel-end gap-5 sm:gap-10 w-full">
-        {posts.map((item, index) => (<Slider.Item index={index} class={clx("carousel-item", "first:pl-5 first:sm:pl-0", "last:pr-5 last:sm:pr-0")}>
+        {posts.map((item, index) => (
+          <Slider.Item
+            index={index}
+            class={clx(
+              "carousel-item",
+              "first:pl-5 first:sm:pl-0",
+              "last:pr-5 last:sm:pr-0",
+            )}
+          >
             <a href={item.permalink} target="_blank">
               {item.media_type === "IMAGE"
-                ? (<Image loading="lazy" class="max-w-full max-h-full object-cover" style={{ aspectRatio: "1 / 1" }} src={item.media_url ?? ""} width={350} height={350}/>)
-                : (<video controls class="max-w-full max-h-full object-cover">
+                ? (
+                  <Image
+                    loading="lazy"
+                    class="max-w-full max-h-full object-cover"
+                    style={{ aspectRatio: "1 / 1" }}
+                    src={item.media_url ?? ""}
+                    width={350}
+                    height={350}
+                  />
+                )
+                : (
+                  <video controls class="max-w-full max-h-full object-cover">
                     <source src={item.media_url}></source>
-                  </video>)}
+                  </video>
+                )}
             </a>
-          </Slider.Item>))}
+          </Slider.Item>
+        ))}
       </Slider>
-    </Section.Container>);
+    </Section.Container>
+  );
 }
-export const LoadingFallback = ({ title }: LoadingFallbackProps<Props>) => (<Section.Container>
-    <Section.Header title={title}/>
-    <Section.Placeholder height="635px"/>
-  </Section.Container>);
+export const LoadingFallback = ({ title }: LoadingFallbackProps<Props>) => (
+  <Section.Container>
+    <Section.Header title={title} />
+    <Section.Placeholder height="635px" />
+  </Section.Container>
+);
 export default InstagramPosts;


### PR DESCRIPTION
Nowadays some events that do not fire "htmx:load" are not adding listeners on any element that has the `data-event` attribute, particularly Sections that do not have (or do not need to) use the individual Async Rendering component `Lazy`.

This wrong behavior can be checked at this environment, without view_promotion events on dataLayer: https://sites-farmrio-oohmmomcxw.decocdn.com/
<img width="1372" alt="image" src="https://github.com/user-attachments/assets/188c35d3-ffb9-4dae-98ba-59622c3f197d">

The fixed version is running at https://farmrio.deco.site/
<img width="1357" alt="image" src="https://github.com/user-attachments/assets/8ea7e85d-e71c-46aa-93f1-d54b783a83ff">
