### PR TITLE
fix: remove extra space in discount badge percentage

### DIFF
--- a/components/product/ProductInfo.tsx
+++ b/components/product/ProductInfo.tsx
@@ -80,7 +80,7 @@ function ProductInfo({ page }: Props) {
           "w-fit",
         )}
       >
-        {percent} % off
+        {percent}% off
       </span>
 
       {/* Product Name */}


### PR DESCRIPTION
## Summary
- Remove extra space between discount number and `%` symbol in the product page badge (`{percent} % off` → `{percent}% off`)

## Test plan
- [ ] Open a product page with discount and verify the badge displays correctly (e.g. `10% off` instead of `10 % off`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)