### PR TITLE
chore: bump deco-cx/apps to 0.147.0

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -33,7 +33,7 @@
     "simple-git": "npm:simple-git@^3.25.0",
     "std/": "https://deno.land/std@0.190.0/",
     "deco/": "https://cdn.jsdelivr.net/gh/deco-cx/deco@1.191.2/",
-    "apps/": "https://cdn.jsdelivr.net/gh/deco-cx/apps@0.144.1/",
+    "apps/": "https://cdn.jsdelivr.net/gh/deco-cx/apps@0.147.0/",
     "@preact/signals": "https://esm.sh/*@preact/signals@1.2.2?external=preact&target=es2020",
     "@preact/signals-core": "https://esm.sh/*@preact/signals-core@1.5.1?external=preact&target=es2020",
     "daisyui": "npm:daisyui@4.6.0",

--- a/deno.json
+++ b/deno.json
@@ -33,7 +33,7 @@
     "simple-git": "npm:simple-git@^3.25.0",
     "std/": "https://deno.land/std@0.190.0/",
     "deco/": "https://cdn.jsdelivr.net/gh/deco-cx/deco@1.191.2/",
-    "apps/": "https://cdn.jsdelivr.net/gh/deco-cx/apps@0.147.0/",
+    "apps/": "https://cdn.jsdelivr.net/gh/deco-cx/apps@0.151.1/",
     "@preact/signals": "https://esm.sh/*@preact/signals@1.2.2?external=preact&target=es2020",
     "@preact/signals-core": "https://esm.sh/*@preact/signals-core@1.5.1?external=preact&target=es2020",
     "daisyui": "npm:daisyui@4.6.0",


### PR DESCRIPTION
Bumps `deco-cx/apps` to [`0.147.0`](https://github.com/deco-cx/apps/releases/tag/0.147.0).

**Release highlight:** _Migrate asset URLs to `decoims.com` (clean cutover, drop `ENABLE_AZION_ASSETS`)._

Opened as a **draft** so CI runs but the PR doesn't auto-merge. If your site uses shared image hosts (assets.decocache.com, deco-assets.edgedeco.com, etc.), this bump migrates those asset URLs to `decoims.com`. Verify image rendering on a preview deployment before marking ready-for-review.

Generated by `scripts/bump-apps-0.147.0/bump.py` (stats-lake repo).