### PR TITLE
content: trim excessive punctuation in home banner title

### DIFF
--- a/.deco/blocks/pages-home.json
+++ b/.deco/blocks/pages-home.json
@@ -18,7 +18,7 @@
           "mobile": "https://assets.decocache.com/storefront/9c8c0ce3-4ffb-49d6-a8d1-fe17a3db7e86/1742560203848-88b2ad41-be6d-4640-b9fe-c58942362f0f",
           "alt": "Shoes",
           "action": {
-            "title": "Skate into Adventure!!!",
+            "title": "Skate into Adventure!",
             "subTitle": "Top-quality roller skate shoes for all levels. ",
             "href": "/s?q=shoes&page=0",
             "label": "Grab Yours Now!"


### PR DESCRIPTION
## Summary

Removes two of the three exclamation marks from the "Skate into Adventure" call-to-action title on the home page banner, leaving a single, clean exclamation mark.

### Changed file
- `.deco/blocks/pages-home.json` — `"Skate into Adventure!!!"` → `"Skate into Adventure!"`

### Why
Triple exclamation marks read as over-eager and inconsistent with the tone of the surrounding copy. A single mark preserves the energy while keeping the text professional.