### PR TITLE
fix(content): remove excess exclamation marks from home banner CTA title

### DIFF
--- a/.deco/blocks/pages-home.json
+++ b/.deco/blocks/pages-home.json
@@ -18,7 +18,7 @@
           "mobile": "https://assets.decocache.com/storefront/9c8c0ce3-4ffb-49d6-a8d1-fe17a3db7e86/1742560203848-88b2ad41-be6d-4640-b9fe-c58942362f0f",
           "alt": "Shoes",
           "action": {
-            "title": "Skate into Adventure!!!",
+            "title": "Skate into Adventure!",
             "subTitle": "Top-quality roller skate shoes for all levels. ",
             "href": "/s?q=shoes&page=0",
             "label": "Grab Yours Now!"


### PR DESCRIPTION
## Summary

Corrects an over-punctuated call-to-action title on the home page hero banner.

### Change

| File | What changed |
|------|-------------|
| `.deco/blocks/pages-home.json` | Banner CTA title: `"Skate into Adventure!!!"` → `"Skate into Adventure!"` |

### Context

A previous commit (#337) added extra exclamation marks to the roller-skate-shoes promotional banner for "increased emphasis". This reverts that specific copy change, keeping a single exclamation mark which is consistent with the tone of the rest of the storefront's content.

No functional, layout, or configuration changes are included.