### PR TITLE
chore: migra assets legados para decoims.com

### DIFF
--- a/.deco/blocks/Header.json
+++ b/.deco/blocks/Header.json
@@ -11,7 +11,7 @@
     "<p>Get 10% off today: <strong>NEW10</strong></p>"
   ],
   "logo": {
-    "src": "https://assets.decocache.com/storefront/0d91c3c0-1062-4b5c-9b77-19c2b6c13bfb/1742560193760-ed9f7e80-86a8-4b72-9809-2e4e2e5f0e53",
+    "src": "https://decoims.com/storefront/4c590317-5ee9-43a0-b077-b90076bc1af8/1742560193760-ed9f7e80-86a8-4b72-9809-2e4e2e5f0e53.png",
     "alt": "Deco Storefront",
     "width": 160,
     "height": 40

--- a/.deco/blocks/pages-home.json
+++ b/.deco/blocks/pages-home.json
@@ -14,8 +14,8 @@
       "__resolveType": "site/sections/Images/Carousel.tsx",
       "images": [
         {
-          "desktop": "https://assets.decocache.com/storefront/08d208f7-3867-4a1e-b898-310bb6a73983/product-1.jpg",
-          "mobile": "https://assets.decocache.com/storefront/9c8c0ce3-4ffb-49d6-a8d1-fe17a3db7e86/1742560203848-88b2ad41-be6d-4640-b9fe-c58942362f0f",
+          "desktop": "https://decoims.com/storefront/2103a140-cb8c-4a6a-8131-3b21185c4317/product-1.jpg",
+          "mobile": "https://decoims.com/storefront/1499fe17-1765-4d70-9f9d-9dba0680a689/1742560203848-88b2ad41-be6d-4640-b9fe-c58942362f0f.jpg",
           "alt": "Shoes",
           "action": {
             "title": "Skate into Adventure!!!",
@@ -25,8 +25,8 @@
           }
         },
         {
-          "desktop": "https://assets.decocache.com/storefront/98a22637-60b2-41f7-9d49-dbbf99f50472/1742560212519-d26304f4-355b-48d0-b649-e24b9cbf0ded",
-          "mobile": "https://assets.decocache.com/storefront/05748b9f-6c37-4845-aa57-1d2338ece0b8/1742560215958-47a4d85a-1150-4e5d-abc2-5c642445ff12",
+          "desktop": "https://decoims.com/storefront/d7147a09-beab-4ca2-9224-e56171973e7f/1742560212519-d26304f4-355b-48d0-b649-e24b9cbf0ded.png",
+          "mobile": "https://decoims.com/storefront/8a3df38f-8f2b-46e9-b046-34afacca0db9/1742560215958-47a4d85a-1150-4e5d-abc2-5c642445ff12.png",
           "alt": "Men",
           "action": {
             "title": "Discover Fresh Looks",
@@ -70,22 +70,22 @@
           {
             "label": "Men",
             "href": "/men",
-            "image": "https://assets.decocache.com/storefront/a1e905ee-e680-41f1-93aa-7e2525214e40/1742560225714-38c33c9f-14a1-4048-973b-dc2a75caf1fa"
+            "image": "https://decoims.com/storefront/4d75d563-742b-40ce-97db-f4fef281dc74/1742560225714-38c33c9f-14a1-4048-973b-dc2a75caf1fa.png"
           },
           {
             "href": "/women",
             "label": "Women",
-            "image": "https://assets.decocache.com/storefront/327048d1-e1d9-4f60-9057-71f823ba2d72/1742560227121-f6bea2b8-b248-4b42-9246-6e924a0acc8b"
+            "image": "https://decoims.com/storefront/221b6f05-a893-430b-bfff-30df3f5bde28/1742560227121-f6bea2b8-b248-4b42-9246-6e924a0acc8b.png"
           },
           {
             "href": "/kids",
             "label": "Kids",
-            "image": "https://assets.decocache.com/storefront/c1d9c142-478f-4ada-912b-1ca918365e72/1742560228502-1b0ecaa2-9a13-4de2-bf17-5196948ed128"
+            "image": "https://decoims.com/storefront/6d1471f0-9252-4b93-bfb9-4c83cefe3fa8/1742560228502-1b0ecaa2-9a13-4de2-bf17-5196948ed128.png"
           },
           {
             "href": "/accessories",
             "label": "Accessories",
-            "image": "https://assets.decocache.com/storefront/38a0d82a-e443-4e7c-aea9-3b8eeb26e40b/1742560230067-92129655-fe40-4b29-8fdb-e7f71e67a5d1"
+            "image": "https://decoims.com/storefront/c6562fe4-94b1-4d2e-afef-4602a2b2a039/1742560230067-92129655-fe40-4b29-8fdb-e7f71e67a5d1.png"
           },
           {
             "href": "/home-and-living",

--- a/apps/site.ts
+++ b/apps/site.ts
@@ -56,7 +56,7 @@ let firstRun = true;
  * @title Site
  * @description Start your site from a template or from scratch.
  * @category Tool
- * @logo https://ozksgdmyrqcxcwhnbepg.supabase.co/storage/v1/object/public/assets/1/0ac02239-61e6-4289-8a36-e78c0975bcc8
+ * @logo https://decoims.com/storefront/b7388cf2-df6f-48c0-ac1c-091623da2649/0ac02239-61e6-4289-8a36-e78c0975bcc8.png
  */
 export default function Site({ ...state }: Props): A<Manifest, Props, [
   ReturnType<typeof commerce>,

--- a/components/ui/CategoryBanner.tsx
+++ b/components/ui/CategoryBanner.tsx
@@ -25,9 +25,9 @@ const DEFAULT_PROPS = {
     {
       image: {
         mobile:
-          "https://ozksgdmyrqcxcwhnbepg.supabase.co/storage/v1/object/public/assets/239/91102b71-4832-486a-b683-5f7b06f649af",
+          "https://decoims.com/storefront/2324c855-7bfc-4fd4-b13e-8c8a2b618c06/91102b71-4832-486a-b683-5f7b06f649af.png",
         desktop:
-          "https://ozksgdmyrqcxcwhnbepg.supabase.co/storage/v1/object/public/assets/239/ec597b6a-dcf1-48ca-a99d-95b3c6304f96",
+          "https://decoims.com/storefront/fafbd9f6-b928-4b8f-bd06-0e2e6b5ce39f/ec597b6a-dcf1-48ca-a99d-95b3c6304f96.png",
         alt: "a",
       },
       title: "Woman",

--- a/sections/Content/Logos.tsx
+++ b/sections/Content/Logos.tsx
@@ -20,12 +20,12 @@ function Logos({
     {
       alt: "deco",
       image:
-        "https://ozksgdmyrqcxcwhnbepg.supabase.co/storage/v1/object/public/assets/239/fe7cd8ba-c954-45d6-9282-ee7d8ca8e3c7",
+        "https://decoims.com/storefront/ba262847-4354-455f-bc83-114226d5cca8/fe7cd8ba-c954-45d6-9282-ee7d8ca8e3c7.svg",
     },
     {
       alt: "deco",
       image:
-        "https://ozksgdmyrqcxcwhnbepg.supabase.co/storage/v1/object/public/assets/239/637e8601-6b86-4979-aa97-68013a2a60fd",
+        "https://decoims.com/storefront/ba45fb4a-fff5-42e6-a655-7855789951e0/637e8601-6b86-4979-aa97-68013a2a60fd.svg",
     },
   ],
 }: Props) {

--- a/sections/Header/Header.tsx
+++ b/sections/Header/Header.tsx
@@ -191,7 +191,7 @@ function Header({
   alerts = [],
   logo = {
     src:
-      "https://ozksgdmyrqcxcwhnbepg.supabase.co/storage/v1/object/public/assets/2291/986b61d4-3847-4867-93c8-b550cb459cc7",
+      "https://decoims.com/storefront/00553fca-7248-4399-a161-1d7eae07057d/986b61d4-3847-4867-93c8-b550cb459cc7.png",
     width: 100,
     height: 16,
     alt: "Logo",

--- a/sections/Images/ImageGallery.tsx
+++ b/sections/Images/ImageGallery.tsx
@@ -56,9 +56,9 @@ function Gallery({
   banners = [
     {
       mobile:
-        "https://ozksgdmyrqcxcwhnbepg.supabase.co/storage/v1/object/public/assets/239/b531631b-8523-4feb-ac37-5112873abad2",
+        "https://decoims.com/storefront/24a5eb54-0964-43ea-9708-ac62863477e5/b531631b-8523-4feb-ac37-5112873abad2.jpg",
       desktop:
-        "https://ozksgdmyrqcxcwhnbepg.supabase.co/storage/v1/object/public/assets/239/b531631b-8523-4feb-ac37-5112873abad2",
+        "https://decoims.com/storefront/24a5eb54-0964-43ea-9708-ac62863477e5/b531631b-8523-4feb-ac37-5112873abad2.jpg",
       alt: "Fashion",
       href: "/",
     },
@@ -66,23 +66,23 @@ function Gallery({
       alt: "Fashion",
       href: "/",
       mobile:
-        "https://ozksgdmyrqcxcwhnbepg.supabase.co/storage/v1/object/public/assets/239/1125d938-89ff-4aae-a354-63d4241394a6",
+        "https://decoims.com/storefront/cd54229b-fd6c-4580-8dbf-f39a002371cc/1125d938-89ff-4aae-a354-63d4241394a6.jpg",
       desktop:
-        "https://ozksgdmyrqcxcwhnbepg.supabase.co/storage/v1/object/public/assets/239/1125d938-89ff-4aae-a354-63d4241394a6",
+        "https://decoims.com/storefront/cd54229b-fd6c-4580-8dbf-f39a002371cc/1125d938-89ff-4aae-a354-63d4241394a6.jpg",
     },
     {
       mobile:
-        "https://ozksgdmyrqcxcwhnbepg.supabase.co/storage/v1/object/public/assets/239/dd1e2acb-ff80-49f9-8f56-1deac3b7a42d",
+        "https://decoims.com/storefront/e298731f-de4c-4358-ac01-3e336d06a45d/dd1e2acb-ff80-49f9-8f56-1deac3b7a42d.jpg",
       desktop:
-        "https://ozksgdmyrqcxcwhnbepg.supabase.co/storage/v1/object/public/assets/239/dd1e2acb-ff80-49f9-8f56-1deac3b7a42d",
+        "https://decoims.com/storefront/e298731f-de4c-4358-ac01-3e336d06a45d/dd1e2acb-ff80-49f9-8f56-1deac3b7a42d.jpg",
       href: "/",
       alt: "Fashion",
     },
     {
       mobile:
-        "https://ozksgdmyrqcxcwhnbepg.supabase.co/storage/v1/object/public/assets/239/0b85ba2d-48b1-4f5b-b619-7f4a7f50b455",
+        "https://decoims.com/storefront/7994ccfe-75c7-486f-8f9b-6aa81857bb7d/0b85ba2d-48b1-4f5b-b619-7f4a7f50b455.jpg",
       desktop:
-        "https://ozksgdmyrqcxcwhnbepg.supabase.co/storage/v1/object/public/assets/239/0b85ba2d-48b1-4f5b-b619-7f4a7f50b455",
+        "https://decoims.com/storefront/7994ccfe-75c7-486f-8f9b-6aa81857bb7d/0b85ba2d-48b1-4f5b-b619-7f4a7f50b455.jpg",
       alt: "Fashion",
       href: "/",
     },

--- a/sections/Images/ShoppableBanner.tsx
+++ b/sections/Images/ShoppableBanner.tsx
@@ -68,7 +68,7 @@ const DEFAULT_PROPS: Props = {
   pins: [],
   image: {
     mobile:
-      "https://ozksgdmyrqcxcwhnbepg.supabase.co/storage/v1/object/public/assets/239/cac2dc1c-48ac-4274-ad42-4016b0bbe947",
+      "https://decoims.com/storefront/d5a01b11-8d86-4db1-b433-1c26c73c0be6/cac2dc1c-48ac-4274-ad42-4016b0bbe947.jpg",
     altText: "Fashion",
   },
 };


### PR DESCRIPTION
Migra **20 assets** (24 substituições em 8 arquivos) de `decocache`/`decoassets`/`supabase`/`s3` para `decoims.com`. Branch a partir da main.

- URLs **sem extensão** tiveram o content-type detectado (`file --mime-type`) e a extensão correta aplicada no upload → decoims serve o tipo certo (sem octet-stream).
- Legado restante após replace: **0** (exceto fontes mortas abaixo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)